### PR TITLE
Remove apt-get install as highlighted in the pen test report

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y curl && \
     rm -rf /var/lib/apt/lists/*
 
 ENV TZ=Europe/London


### PR DESCRIPTION
Remove apt-get install as highlighted in the pen test report - https://docs.google.com/document/d/167kRblNjIcpp7LEPJC4hoWCkGfYkg6Eh/edit