### PR TITLE
VB-4785 - Rework template retrieval and organise service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,8 +36,7 @@ dependencies {
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
   implementation("org.springdoc:springdoc-openapi-starter-common:2.6.0")
   implementation("uk.gov.service.notify:notifications-java-client:5.2.1-RELEASE")
-
-  annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+  implementation("org.springframework.boot:spring-boot-configuration-processor")
 
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.22")
   testImplementation("com.github.tomakehurst:wiremock-jre8-standalone:3.0.1")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/config/SmsTemplatesConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/config/SmsTemplatesConfig.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.notificationsalertsvsip.config
+
+import jakarta.validation.constraints.NotNull
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+import org.springframework.validation.annotation.Validated
+
+@Component
+@ConfigurationProperties(prefix = "notify.sms")
+@Validated
+class SmsTemplatesConfig {
+  @NotNull
+  var templates: MutableMap<String, String> = HashMap()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/enums/SmsTemplateNames.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/enums/SmsTemplateNames.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums
+
+enum class SmsTemplateNames {
+  VISIT_BOOKING,
+  VISIT_UPDATE,
+  VISIT_CANCEL,
+  VISIT_CANCEL_NO_PRISON_NUMBER,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/enums/VisitEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/enums/VisitEventType.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums
+
+enum class VisitEventType { BOOKED, UPDATED, CANCELLED }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/NotificationService.kt
@@ -2,37 +2,22 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.client.PrisonRegisterClient
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.client.VisitSchedulerClient
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
-import java.time.LocalDate
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.VisitEventType
 import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.format.DateTimeFormatter
 
 @Service
 class NotificationService(
   val visitSchedulerClient: VisitSchedulerClient,
-  val prisonRegisterClient: PrisonRegisterClient,
   val smsSenderService: SmsSenderService,
-  @Value("\${notify.template-id.visit-booking:}") private val visitBookingTemplateId: String,
-  @Value("\${notify.template-id.visit-update:}") private val visitUpdateTemplateId: String,
-  @Value("\${notify.template-id.visit-cancel:}") private val visitCancelTemplateId: String,
-  @Value("\${notify.template-id.visit-cancel-no-prison-number:}") private val visitCancelNoPrisonNumberTemplateId: String,
 ) {
   private companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
-    private const val SMS_DATE_PATTERN = "d MMMM yyyy"
-    private const val SMS_TIME_PATTERN = "h:mma"
-    private const val SMS_TIME_PATTERN_WHEN_MNIUTES_IS_ZERO = "ha"
-    private const val SMS_DAY_OF_WEEK_PATTERN = "EEEE"
   }
-
-  enum class VisitEventType { BOOKED, UPDATED, CANCELLED }
 
   fun sendMessage(visitEventType: VisitEventType, bookingReference: String) {
     LOG.info("Visit booked event with reference - $bookingReference")
@@ -40,48 +25,10 @@ class NotificationService(
     val visit = getVisit(bookingReference)
 
     visit?.let {
-      if (visit.startTimestamp > LocalDateTime.now()) {
-        val telephoneNumber = visit.visitContact.telephone
-        if (!telephoneNumber.isNullOrEmpty()) {
-          val prisonName = getPrisonName(visit.prisonCode)
-          val templateId: String
-          val visitDetailsMap = mutableMapOf(
-            "prison" to prisonName,
-            "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
-            "dayofweek" to getFormattedDayOfWeek(visit.startTimestamp.toLocalDate()),
-            "date" to getFormattedDate(visit.startTimestamp.toLocalDate()),
-          )
-
-          when (visitEventType) {
-            VisitEventType.BOOKED, VisitEventType.UPDATED -> {
-              templateId = getNotificationTemplateId(visitEventType)
-              visitDetailsMap["ref number"] = visit.reference
-            }
-
-            VisitEventType.CANCELLED -> {
-              val prisonContactNumber: String? = getPrisonSocialVisitsContactNumber(visit.prisonCode)
-              val prisonPhoneNumberAvailable = !prisonContactNumber.isNullOrEmpty()
-              templateId = getNotificationTemplateId(visitEventType, prisonPhoneNumberAvailable)
-              visitDetailsMap["reference"] = visit.reference
-
-              if (prisonPhoneNumberAvailable) {
-                visitDetailsMap["prison phone number"] = prisonContactNumber!!
-              }
-            }
-          }
-
-          // send the SMS
-          smsSenderService.sendSms(
-            templateId,
-            telephoneNumber,
-            visitDetailsMap.toMap(),
-            visit.reference,
-          )
-        } else {
-          LOG.info("No telephone number exists for contact on visit reference - ${visit.reference}")
-        }
+      if (visit.startTimestamp > LocalDateTime.now() && !visit.visitContact.telephone.isNullOrEmpty()) {
+        smsSenderService.sendSms(visit, visitEventType)
       } else {
-        LOG.info("Visit with reference - ${visit.reference} is in the past.")
+        LOG.info("Visit in past or no telephone number exists for contact on visit reference - ${visit.reference}")
       }
     }
   }
@@ -95,50 +42,7 @@ class NotificationService(
         LOG.error("no visit found with booking reference - $bookingReference")
         return null
       }
-
       throw e
     }
-  }
-
-  private fun getPrisonSocialVisitsContactNumber(prisonCode: String): String? {
-    return try {
-      prisonRegisterClient.getSocialVisitContact(prisonCode)?.phoneNumber
-    } catch (e: Exception) {
-      // if there was an error getting the social visit contact return null
-      LOG.info("no social visit contact number returned for prison - $prisonCode")
-      null
-    }
-  }
-
-  private fun getNotificationTemplateId(visitEventType: VisitEventType, prisonPhoneNumberAvailable: Boolean? = false): String {
-    return when (visitEventType) {
-      VisitEventType.BOOKED -> visitBookingTemplateId
-      VisitEventType.UPDATED -> visitUpdateTemplateId
-      VisitEventType.CANCELLED -> if (prisonPhoneNumberAvailable == true) visitCancelTemplateId else visitCancelNoPrisonNumberTemplateId
-    }
-  }
-
-  private fun getPrisonName(prisonCode: String): String {
-    // get prison details from prison register
-    val prison = prisonRegisterClient.getPrison(prisonCode)
-    return prison?.prisonName ?: prisonCode
-  }
-
-  private fun getFormattedDate(visitDate: LocalDate): String {
-    return visitDate.format(DateTimeFormatter.ofPattern(SMS_DATE_PATTERN))
-  }
-
-  private fun getFormattedTime(visitStartTime: LocalTime): String {
-    val formatter = if (visitStartTime.minute == 0) {
-      DateTimeFormatter.ofPattern(SMS_TIME_PATTERN_WHEN_MNIUTES_IS_ZERO)
-    } else {
-      DateTimeFormatter.ofPattern(SMS_TIME_PATTERN)
-    }
-
-    return visitStartTime.format(formatter).lowercase()
-  }
-
-  private fun getFormattedDayOfWeek(visitDate: LocalDate): String {
-    return visitDate.format(DateTimeFormatter.ofPattern(SMS_DAY_OF_WEEK_PATTERN))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/SmsSenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/SmsSenderService.kt
@@ -4,23 +4,118 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.client.PrisonRegisterClient
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.config.SmsTemplatesConfig
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNames
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.VisitEventType
 import uk.gov.service.notify.NotificationClient
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 
 @Service
 class SmsSenderService(
   @Value("\${notify.sms.enabled:}")
   private val enabled: Boolean,
   val notificationClient: NotificationClient,
+  val prisonRegisterClient: PrisonRegisterClient,
+  val smsTemplateConfig: SmsTemplatesConfig,
 ) {
   private companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+    private const val SMS_DATE_PATTERN = "d MMMM yyyy"
+    private const val SMS_TIME_PATTERN = "h:mma"
+    private const val SMS_TIME_PATTERN_WHEN_MINUTES_IS_ZERO = "ha"
+    private const val SMS_DAY_OF_WEEK_PATTERN = "EEEE"
   }
 
-  fun sendSms(templateID: String, phoneNumber: String, personalisation: Map<String, String>, reference: String) {
+  fun sendSms(visit: VisitDto, visitEventType: VisitEventType) {
     if (enabled) {
-      notificationClient.sendSms(templateID, phoneNumber, personalisation, reference)
+      val templateVars = getCommonTemplateVars(visit)
+
+      val templateName: SmsTemplateNames
+
+      when (visitEventType) {
+        VisitEventType.BOOKED -> {
+          templateVars["ref number"] = visit.reference
+          templateName = SmsTemplateNames.VISIT_BOOKING
+        }
+
+        VisitEventType.UPDATED -> {
+          templateVars["ref number"] = visit.reference
+          templateName = SmsTemplateNames.VISIT_UPDATE
+        }
+
+        VisitEventType.CANCELLED -> {
+          templateVars["reference"] = visit.reference
+
+          val prisonContactNumber: String? = getPrisonSocialVisitsContactNumber(visit.prisonCode)
+          if (!prisonContactNumber.isNullOrEmpty()) {
+            templateVars["prison phone number"] = prisonContactNumber
+            templateName = SmsTemplateNames.VISIT_CANCEL
+          } else {
+            templateName = SmsTemplateNames.VISIT_CANCEL_NO_PRISON_NUMBER
+          }
+        }
+      }
+
+      val templateId = smsTemplateConfig.templates[templateName.name]
+
+      notificationClient.sendSms(
+        templateId,
+        visit.visitContact.telephone,
+        templateVars,
+        visit.reference,
+      )
     } else {
       LOG.info("Sending SMS has been disabled.")
     }
+  }
+
+  private fun getCommonTemplateVars(visit: VisitDto): MutableMap<String, String> {
+    val prisonName = getPrisonName(visit.prisonCode)
+
+    val templateVars = mutableMapOf(
+      "prison" to prisonName,
+      "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
+      "dayofweek" to getFormattedDayOfWeek(visit.startTimestamp.toLocalDate()),
+      "date" to getFormattedDate(visit.startTimestamp.toLocalDate()),
+    )
+    return templateVars
+  }
+
+  private fun getPrisonSocialVisitsContactNumber(prisonCode: String): String? {
+    return try {
+      prisonRegisterClient.getSocialVisitContact(prisonCode)?.phoneNumber
+    } catch (e: Exception) {
+      // if there was an error getting the social visit contact return null
+      LOG.info("no social visit contact number returned for prison - $prisonCode")
+      null
+    }
+  }
+
+  private fun getPrisonName(prisonCode: String): String {
+    // get prison details from prison register
+    val prison = prisonRegisterClient.getPrison(prisonCode)
+    return prison?.prisonName ?: prisonCode
+  }
+
+  private fun getFormattedDate(visitDate: LocalDate): String {
+    return visitDate.format(DateTimeFormatter.ofPattern(SMS_DATE_PATTERN))
+  }
+
+  private fun getFormattedTime(visitStartTime: LocalTime): String {
+    val formatter = if (visitStartTime.minute == 0) {
+      DateTimeFormatter.ofPattern(SMS_TIME_PATTERN_WHEN_MINUTES_IS_ZERO)
+    } else {
+      DateTimeFormatter.ofPattern(SMS_TIME_PATTERN)
+    }
+
+    return visitStartTime.format(formatter).lowercase()
+  }
+
+  private fun getFormattedDayOfWeek(visitDate: LocalDate): String {
+    return visitDate.format(DateTimeFormatter.ofPattern(SMS_DAY_OF_WEEK_PATTERN))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/PrisonVisitBookedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/PrisonVisitBookedEventNotifier.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.n
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.VisitEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.NotificationService
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.NotificationService.VisitEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitAdditionalInfo
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/PrisonVisitCancelledEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/PrisonVisitCancelledEventNotifier.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.n
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.VisitEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.NotificationService
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.NotificationService.VisitEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitAdditionalInfo
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/PrisonVisitChangedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/PrisonVisitChangedEventNotifier.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.n
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.VisitEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.NotificationService
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.NotificationService.VisitEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitAdditionalInfo
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,8 +81,9 @@ hmpps:
 
 notify:
   apikey: ${notify.api.key}
-  template-id:
-    visit-booking: 85904166-e539-43f5-9f51-7ba106cc61bd
-    visit-update: 386e83ff-5734-4d99-8279-b3eacb7cc8b8
-    visit-cancel: 42a995f2-abbc-474b-8563-ca2995529111
-    visit-cancel-no-prison-number: 3103b319-267d-4265-83a6-a38e93fc2342
+  sms:
+    templates:
+      VISIT_BOOKING: 85904166-e539-43f5-9f51-7ba106cc61bd
+      VISIT_UPDATE: 386e83ff-5734-4d99-8279-b3eacb7cc8b8
+      VISIT_CANCEL: 42a995f2-abbc-474b-8563-ca2995529111
+      VISIT_CANCEL_NO_PRISON_NUMBER: 3103b319-267d-4265-83a6-a38e93fc2342

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
@@ -16,6 +17,7 @@ import org.springframework.test.context.DynamicPropertySource
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.config.SmsTemplatesConfig
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.ContactDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.helper.JwtAuthHelper
@@ -36,6 +38,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.no
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
+import uk.gov.service.notify.NotificationClient
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
@@ -85,6 +88,9 @@ abstract class EventsIntegrationTestBase {
   lateinit var smsSenderService: SmsSenderService
 
   @SpyBean
+  lateinit var smsTemplatesConfig: SmsTemplatesConfig
+
+  @SpyBean
   lateinit var prisonVisitBookedEventNotifierSpy: PrisonVisitBookedEventNotifier
 
   @SpyBean
@@ -92,6 +98,9 @@ abstract class EventsIntegrationTestBase {
 
   @SpyBean
   lateinit var prisonVisitCancelledEventNotifierSpy: PrisonVisitCancelledEventNotifier
+
+  @MockBean
+  lateinit var notificationClient: NotificationClient
 
   @Autowired
   protected lateinit var objectMapper: ObjectMapper

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -39,6 +39,6 @@ prison-register:
 
 notify:
   sms:
-    enabled: false
+    enabled: true
   api:
     key: "test"


### PR DESCRIPTION
## What does this PR do?

Instead of loading each templateId individually with a qualifier, we now make use of spring-boots auto-wiring and component scanning to pre-populate at start-up all template names / ids in a Map<String, String>. This is later called in conjuncture with the use of a new enum class SmsTemplateNames to retrive the correct template depending on the event given.

Moved all logic into SmsSenderService to get better coverage of actual API usage.

Re-worked tests to account for all changes.