### PR TITLE
Add booker_cancelled outcome status as supported cancellation outcome for public users

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/EmailSenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/EmailSenderService.kt
@@ -108,7 +108,7 @@ class EmailSenderService(
         EmailTemplateNames.VISIT_CANCELLED_BY_PRISON
       }
 
-      "VISITOR_CANCELLED" -> {
+      "VISITOR_CANCELLED", "BOOKER_CANCELLED" -> {
         EmailTemplateNames.VISIT_CANCELLED
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitCancelledEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitCancelledEventEmailTest.kt
@@ -40,7 +40,7 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
       duration = Duration.of(30, ChronoUnit.MINUTES),
       visitContact = ContactDto("Contact One", email = "example@email.com"),
       visitors = listOf(VisitorDto(1234), VisitorDto(9876)),
-      outcomeStatus = "VISITOR_CANCELLED",
+      outcomeStatus = "BOOKER_CANCELLED",
     )
 
     prison = PrisonDto("HEI", "Hewell", true)


### PR DESCRIPTION
Required as the frontend is sending this to our API.