### PR TITLE
Updated Notify templateID for visits cancelled by prisoner

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ info.app:
   description: VSIP notifications alerts sends out notifications to various actors that use the system
   contact:
     name: Visit Someone in Prison
-    email: prisonvisitsbooking@digital.justice.gov.uk
+    email: prison-visits@justice.gov.uk
 
 spring:
   application:
@@ -89,5 +89,5 @@ notify:
   email-templates:
     VISIT_BOOKING: 35dffc03-c13a-4838-90f9-ade9fc325616
     VISIT_CANCELLED: 37c64f9f-67b7-47de-ad61-c739a9d80f35
-    VISIT_CANCELLED_BY_PRISONER: bb6bb915-60dd-4bbc-aa25-4d3b59ca5d6a
+    VISIT_CANCELLED_BY_PRISONER: 97d4d521-0142-4d50-a37d-de759b85f4e2
     VISIT_CANCELLED_BY_PRISON: eb9e2cf2-ffbf-4469-bce1-d6410bee04a2


### PR DESCRIPTION
Replacing the templateID that was accidentally removed from Notify