### PR TITLE
Vb 4902 [Part-1] - Create new logic to handle saving initial sending of notifications via visit-scheduler

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/client/VisitSchedulerClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/client/VisitSchedulerClient.kt
@@ -6,9 +6,11 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.NotifyCreateNotificationDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.ClientUtils.Companion.isNotFoundError
 import java.time.Duration
@@ -39,6 +41,17 @@ class VisitSchedulerClient(
           return@onErrorResume Mono.empty()
         }
       }
+      .block(apiTimeout)
+  }
+
+  fun createNotifyNotification(notifyCreateNotificationDto: NotifyCreateNotificationDto) {
+    webClient.post()
+      .uri("visits/notify/create")
+      .body(BodyInserters.fromValue(notifyCreateNotificationDto))
+      .accept(MediaType.APPLICATION_JSON)
+      .retrieve()
+      .toBodilessEntity()
+      .doOnError { e -> LOG.error("Could not createNotifyNotification :", e) }
       .block(apiTimeout)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/NotifyCallbackNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/NotifyCallbackNotificationDto.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Gov Notify Callback Notification")
+data class NotifyCallbackNotificationDto(
+  @Schema(description = "The UUID of the notification", required = true)
+  val id: Long,
+  @Schema(description = "The id of the event audit which the notification is linked to", example = "123456", required = true)
+  @JsonProperty("reference")
+  val eventAuditId: Long,
+  @Schema(description = "The final status of the notification", required = true)
+  val status: String,
+  @Schema(description = "The timestamp for when the vsip notification service sent the notification to gov notify", required = true)
+  val createdAt: LocalDateTime,
+  @Schema(description = "The timestamp for the final update of the notification (when delivered or ultimately failed) ", required = false)
+  val completedAt: LocalDateTime?,
+  @Schema(description = "The timestamp for when gov notify sent the notification", required = false)
+  val sentAt: LocalDateTime?,
+  @Schema(description = "The type of the notification", example = "email", required = true)
+  val notificationType: String,
+  @Schema(description = "The id the template used for the notification", example = "email", required = true)
+  val templateId: String,
+  @Schema(description = "The version of the template used for the notification", example = "email", required = true)
+  val templateVersion: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/NotifyCreateNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/NotifyCreateNotificationDto.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.service.notify.SendEmailResponse
+import uk.gov.service.notify.SendSmsResponse
+import java.time.LocalDateTime
+import java.util.*
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Gov Notify Create Notification")
+data class NotifyCreateNotificationDto(
+  @Schema(description = "The UUID of the notification", required = true)
+  val id: UUID,
+  @Schema(description = "The id of the event audit which the notification is linked to", example = "123456", required = true)
+  @JsonProperty("reference")
+  val eventAuditId: String,
+  @Schema(description = "The timestamp for when the vsip notification service sent the notification to gov notify", required = true)
+  val createdAt: LocalDateTime,
+  @Schema(description = "The type of the notification", example = "email", required = true)
+  val notificationType: String,
+  @Schema(description = "The id the template used for the notification", example = "email", required = true)
+  val templateId: UUID,
+  @Schema(description = "The version of the template used for the notification", example = "email", required = true)
+  val templateVersion: Int,
+) {
+  constructor(sendEmailResponse: SendEmailResponse) : this(
+    id = sendEmailResponse.notificationId,
+    eventAuditId = sendEmailResponse.reference.toString(),
+    createdAt = LocalDateTime.now(),
+    notificationType = "email",
+    templateId = sendEmailResponse.templateId,
+    templateVersion = sendEmailResponse.templateVersion,
+  )
+
+  constructor(sendSmsResponse: SendSmsResponse) : this(
+    id = sendSmsResponse.notificationId,
+    eventAuditId = sendSmsResponse.reference.toString(),
+    createdAt = LocalDateTime.now(),
+    notificationType = "sms",
+    templateId = sendSmsResponse.templateId,
+    templateVersion = sendSmsResponse.templateVersion,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/EmailSenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/EmailSenderService.kt
@@ -55,8 +55,8 @@ class EmailSenderService(
         }
       }
 
-      LOG.info("Calling notification client")
       try {
+        LOG.info("Calling notification client")
         val response = notificationClient.sendEmail(
           templatesConfig.emailTemplates[sendEmailNotificationDto.templateName.name],
           visit.visitContact.email,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/NotificationService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.VisitEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitAdditionalInfo
 import java.time.LocalDateTime
@@ -18,28 +19,42 @@ class NotificationService(
   }
 
   fun sendMessage(visitEventType: VisitEventType, additionalInfo: VisitAdditionalInfo) {
-    LOG.info("Received call to send notification for event type $visitEventType, visit - $additionalInfo.bookingReference")
+    LOG.info("Received call to send notification for event type $visitEventType, visit - ${additionalInfo.bookingReference}")
 
     val visit = visitSchedulerService.getVisit(additionalInfo.bookingReference)
-    visit?.let {
-      if (visit.startTimestamp > LocalDateTime.now()) {
-        if (!visit.visitContact.telephone.isNullOrEmpty()) {
-          smsSenderService.sendSms(visit, visitEventType)
-        } else {
-          LOG.info("No telephone number exists for contact on visit reference - ${visit.reference}")
-        }
-
-        if (!visit.visitContact.email.isNullOrEmpty()) {
-          val notifyCreateNotificationDto = emailSenderService.sendEmail(visit, visitEventType, additionalInfo.eventAuditId)
-          notifyCreateNotificationDto?.let {
-            visitSchedulerService.createNotifyNotification(it)
-          }
-        } else {
-          LOG.info("No email exists for contact on visit reference - ${visit.reference}")
-        }
-      } else {
-        LOG.info("Visit in past - ${visit.reference}")
-      }
+    if (visit == null) {
+      LOG.warn("No visit found for booking reference ${additionalInfo.bookingReference}")
+      return
     }
+
+    if (visit.startTimestamp <= LocalDateTime.now()) {
+      LOG.info("Visit in the past - ${visit.reference}")
+      return
+    }
+
+    sendSmsNotificationIfAvailable(visit, visitEventType, additionalInfo)
+    sendEmailNotificationIfAvailable(visit, visitEventType, additionalInfo)
+  }
+
+  private fun sendSmsNotificationIfAvailable(visit: VisitDto, visitEventType: VisitEventType, additionalInfo: VisitAdditionalInfo) {
+    val telephone = visit.visitContact.telephone
+    if (telephone.isNullOrEmpty()) {
+      LOG.info("No telephone number exists for contact on visit reference - ${visit.reference}")
+      return
+    }
+
+    val notification = smsSenderService.sendSms(visit, visitEventType, additionalInfo.eventAuditId)
+    notification?.let { visitSchedulerService.createNotifyNotification(it) }
+  }
+
+  private fun sendEmailNotificationIfAvailable(visit: VisitDto, visitEventType: VisitEventType, additionalInfo: VisitAdditionalInfo) {
+    val email = visit.visitContact.email
+    if (email.isNullOrEmpty()) {
+      LOG.info("No email exists for contact on visit reference - ${visit.reference}")
+      return
+    }
+
+    val notification = emailSenderService.sendEmail(visit, visitEventType, additionalInfo.eventAuditId)
+    notification?.let { visitSchedulerService.createNotifyNotification(it) }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/NotificationService.kt
@@ -27,7 +27,7 @@ class NotificationService(
       return
     }
 
-    if (visit.startTimestamp <= LocalDateTime.now()) {
+    if (visit.startTimestamp < LocalDateTime.now()) {
       LOG.info("Visit in the past - ${visit.reference}")
       return
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/VisitSchedulerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/VisitSchedulerService.kt
@@ -4,6 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.client.VisitSchedulerClient
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.NotifyCreateNotificationDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
 
 @Service
@@ -17,5 +18,9 @@ class VisitSchedulerService(
   fun getVisit(bookingReference: String): VisitDto? {
     LOG.info("VisitSchedulerService getVisit entered, booking reference - $bookingReference")
     return visitSchedulerClient.getVisitByReference(bookingReference)
+  }
+
+  fun createNotifyNotification(notifyCreateNotificationDto: NotifyCreateNotificationDto) {
+    visitSchedulerClient.createNotifyNotification(notifyCreateNotificationDto)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/events/additionalinfo/VisitAdditionalInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/events/additionalinfo/VisitAdditionalInfo.kt
@@ -7,4 +7,6 @@ data class VisitAdditionalInfo(
   @JsonProperty("reference")
   @NotBlank
   val bookingReference: String,
+  @NotBlank
+  val eventAuditId: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/PrisonVisitBookedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/PrisonVisitBookedEventNotifier.kt
@@ -18,6 +18,6 @@ class PrisonVisitBookedEventNotifier(
   override fun processEvent(domainEvent: DomainEvent) {
     val visitAdditionalInfo: VisitAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation)
     LOG.debug("Enter booking event with info : {}", visitAdditionalInfo)
-    notificationService.sendMessage(VisitEventType.BOOKED, visitAdditionalInfo.bookingReference)
+    notificationService.sendMessage(VisitEventType.BOOKED, visitAdditionalInfo)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/PrisonVisitCancelledEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/PrisonVisitCancelledEventNotifier.kt
@@ -18,6 +18,6 @@ class PrisonVisitCancelledEventNotifier(
   override fun processEvent(domainEvent: DomainEvent) {
     val visitAdditionalInfo: VisitAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation)
     LOG.debug("Enter cancel event with info {}", visitAdditionalInfo)
-    notificationService.sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo.bookingReference)
+    notificationService.sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/PrisonVisitChangedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/PrisonVisitChangedEventNotifier.kt
@@ -18,6 +18,6 @@ class PrisonVisitChangedEventNotifier(
   override fun processEvent(domainEvent: DomainEvent) {
     val visitAdditionalInfo: VisitAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation)
     LOG.debug("Enter change event with info {}", visitAdditionalInfo)
-    notificationService.sendMessage(VisitEventType.UPDATED, visitAdditionalInfo.bookingReference)
+    notificationService.sendMessage(VisitEventType.UPDATED, visitAdditionalInfo)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
@@ -9,12 +9,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
@@ -96,34 +96,34 @@ abstract class EventsIntegrationTestBase {
   @Autowired
   lateinit var domainEventListenerService: DomainEventListenerService
 
-  @SpyBean
+  @MockitoSpyBean
   lateinit var eventFeatureSwitch: EventFeatureSwitch
 
-  @SpyBean
+  @MockitoSpyBean
   lateinit var notificationService: NotificationService
 
-  @SpyBean
+  @MockitoSpyBean
   lateinit var smsSenderService: SmsSenderService
 
-  @SpyBean
+  @MockitoSpyBean
   lateinit var emailSenderService: EmailSenderService
 
-  @SpyBean
+  @MockitoSpyBean
   lateinit var visitSchedulerService: VisitSchedulerService
 
-  @SpyBean
+  @MockitoSpyBean
   lateinit var templatesConfig: TemplatesConfig
 
-  @SpyBean
+  @MockitoSpyBean
   lateinit var prisonVisitBookedEventNotifierSpy: PrisonVisitBookedEventNotifier
 
-  @SpyBean
+  @MockitoSpyBean
   lateinit var prisonVisitChangedEventNotifierSpy: PrisonVisitChangedEventNotifier
 
-  @SpyBean
+  @MockitoSpyBean
   lateinit var prisonVisitCancelledEventNotifierSpy: PrisonVisitCancelledEventNotifier
 
-  @MockBean
+  @MockitoBean
   lateinit var notificationClient: NotificationClient
 
   @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
@@ -37,6 +37,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.SmsSenderSer
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.EventFeatureSwitch
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.SQSMessage
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitAdditionalInfo
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.PrisonVisitBookedEventNotifier
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.PrisonVisitCancelledEventNotifier
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.PrisonVisitChangedEventNotifier
@@ -182,12 +183,13 @@ abstract class EventsIntegrationTestBase {
     return "{\"eventType\":\"$eventType\",\"additionalInformation\":$additionalInformation}"
   }
 
-  fun createAdditionalInformationJson(bookingReference: String): String {
+  fun createAdditionalInformationJson(visitAdditionalInfo: VisitAdditionalInfo): String {
     val builder = StringBuilder()
     builder.append("{")
-    builder.append("\"reference\":\"$bookingReference\"")
+    builder.append("\"reference\":\"${visitAdditionalInfo.bookingReference}\",")
+    builder.append("\"eventAuditId\":\"${visitAdditionalInfo.eventAuditId}\"")
     builder.append("}")
-    return builder.toString()
+    return builder.toString();
   }
 
   fun createVisitDto(bookingReference: String, prisonCode: String = "HEI", prisonerId: String = "AA123456", visitDate: LocalDate, visitTime: LocalTime, duration: Duration, visitContact: ContactDto, visitRestriction: VisitRestriction = VisitRestriction.OPEN, visitors: List<VisitorDto>, outcomeStatus: String? = null): VisitDto {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
@@ -189,7 +189,7 @@ abstract class EventsIntegrationTestBase {
     builder.append("\"reference\":\"${visitAdditionalInfo.bookingReference}\",")
     builder.append("\"eventAuditId\":\"${visitAdditionalInfo.eventAuditId}\"")
     builder.append("}")
-    return builder.toString();
+    return builder.toString()
   }
 
   fun createVisitDto(bookingReference: String, prisonCode: String = "HEI", prisonerId: String = "AA123456", visitDate: LocalDate, visitTime: LocalTime, duration: Duration, visitContact: ContactDto, visitRestriction: VisitRestriction = VisitRestriction.OPEN, visitors: List<VisitorDto>, outcomeStatus: String? = null): VisitDto {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
@@ -48,6 +48,7 @@ import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
 import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.SendEmailResponse
+import uk.gov.service.notify.SendSmsResponse
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
@@ -249,5 +250,38 @@ abstract class EventsIntegrationTestBase {
     }.toString()
 
     return SendEmailResponse(jsonResponse)
+  }
+
+  fun buildSendSmsResponse(
+    id: UUID = UUID.randomUUID(),
+    reference: String?,
+    body: String = "Hello, {{name}}!",
+    fromNumber: String? = "no-reply@example.com",
+    templateId: UUID = UUID.randomUUID(),
+    templateVersion: Int = 1,
+    templateUri: String = "https://example.com/template/template-id",
+  ): SendSmsResponse {
+    val jsonResponse = JSONObject().apply {
+      put("id", id.toString())
+      put("reference", reference)
+      put(
+        "content",
+        JSONObject().apply {
+          put("body", body)
+          put("from_number", fromNumber)
+        },
+      )
+
+      put(
+        "template",
+        JSONObject().apply {
+          put("id", templateId.toString())
+          put("version", templateVersion)
+          put("uri", templateUri)
+        },
+      )
+    }.toString()
+
+    return SendSmsResponse(jsonResponse)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitBookedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitBookedEventEmailTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateNames
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.VisitEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.EventsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitAdditionalInfo
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.PRISON_VISIT_BOOKED
 import java.time.Duration
 import java.time.LocalDate
@@ -125,8 +126,9 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
   fun `when visit booked message is received then booking email is sent`() {
     // Given
     val bookingReference = visit.reference
+    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
 
-    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(bookingReference))
+    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_BOOKING.name]
@@ -160,14 +162,14 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, "bi-vn-wn-ml") }
-    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visit, VisitEventType.BOOKED) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendEmail(
         templateId,
         visit.visitContact.email,
         templateVars,
-        visit.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
@@ -176,7 +178,8 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
   fun `when visit booked message is received then booking email is sent in the right time format when start time minutes is 01`() {
     // Given
     val bookingReference = visit3.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit3.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -210,14 +213,14 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, "qq-yy-xx-kk") }
-    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visit3, VisitEventType.BOOKED) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visit3, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendEmail(
         templateId,
         visit3.visitContact.email,
         templateVars,
-        visit3.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
@@ -226,7 +229,8 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
   fun `when visit booked message is received then booking email is sent in the right time format when start time minutes is 00`() {
     // Given
     val bookingReference = visit2.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit2.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -260,14 +264,14 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, "zz-yy-xx-kk") }
-    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visit2, VisitEventType.BOOKED) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visit2, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendEmail(
         templateId,
         visit2.visitContact.email,
         templateVars,
-        visit2.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
@@ -276,7 +280,8 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
   fun `when visit booked message is received but the visit could not be found then booking email is not sent`() {
     // Given
     val bookingReference = visit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -286,15 +291,16 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, "bi-vn-wn-ml") }
-    await untilAsserted { verify(emailSenderService, times(0)).sendEmail(any(), any()) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(0)).sendEmail(any(), any(), any()) }
   }
 
   @Test
   fun `when visit booked message is received but the visit is in the past then booking email is not sent`() {
     // Given
     val bookingReference = pastDatedVisit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(pastDatedVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -304,15 +310,16 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, "aa-bb-cc-dd") }
-    await untilAsserted { verify(emailSenderService, times(0)).sendEmail(any(), any()) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(0)).sendEmail(any(), any(), any()) }
   }
 
   @Test
   fun `when visit booked message is received but no visit contact found then booking email is not sent`() {
     // Given
     val bookingReference = noContactVisit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(noContactVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -322,15 +329,16 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, "bb-cc-dd-zz") }
-    await untilAsserted { verify(emailSenderService, times(0)).sendEmail(any(), any()) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(0)).sendEmail(any(), any(), any()) }
   }
 
   @Test
   fun `when single digit visit date booked then message is sent out with the right visit date format`() {
     // Given
     val bookingReference = singleDigitDateVisit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(singleDigitDateVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // expected visit date should not be 2 digits
@@ -365,14 +373,14 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, "bb-cc-dd-xd") }
-    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(singleDigitDateVisit, VisitEventType.BOOKED) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(singleDigitDateVisit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendEmail(
         templateId,
         singleDigitDateVisit.visitContact.email,
         templateVars,
-        singleDigitDateVisit.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
@@ -381,9 +389,11 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
   fun `when visit booked message is received but and only matching visitors are on the booking email`() {
     // Given
     val bookingReference = visitWithOneVisitor.reference
+    val visitAdditionalInfo = VisitAdditionalInfo(visitWithOneVisitor.reference, "123456")
+
     prisonVisitors = listOf("Visitor One (29 years old)")
 
-    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(bookingReference))
+    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_BOOKING.name]
@@ -417,14 +427,14 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, "bi-vn-wn-ml") }
-    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visitWithOneVisitor, VisitEventType.BOOKED) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visitWithOneVisitor, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendEmail(
         templateId,
         visitWithOneVisitor.visitContact.email,
         templateVars,
-        visitWithOneVisitor.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
@@ -433,8 +443,8 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
   fun `when visit booked message is received and prisoner-contact-registry returns an error, booking email is still sent`() {
     // Given
     val bookingReference = visit.reference
-
-    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_BOOKING.name]
@@ -468,14 +478,14 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, "bi-vn-wn-ml") }
-    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visit, VisitEventType.BOOKED) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendEmail(
         templateId,
         visit.visitContact.email,
         templateVars,
-        visit.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
@@ -484,8 +494,9 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
   fun `when visit booked message is received and prisoner-search returns an error, booking email is still sent`() {
     // Given
     val bookingReference = visit.reference
+    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
 
-    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(bookingReference))
+    val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_BOOKING.name]
@@ -519,14 +530,14 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, "bi-vn-wn-ml") }
-    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visit, VisitEventType.BOOKED) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendEmail(
         templateId,
         visit.visitContact.email,
         templateVars,
-        visit.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitBookedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitBookedEventEmailTest.kt
@@ -120,12 +120,12 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
   fun `when visit booked message is received then booking email is sent in the right time format when start time minutes is 01`() {
     // Given
     val visit3 = createVisitDto(
-    bookingReference = "qq-yy-xx-kk",
-    visitDate = LocalDate.now().plusDays(1),
-    visitTime = LocalTime.of(0, 1),
-    duration = Duration.of(30, ChronoUnit.MINUTES),
-    visitContact = ContactDto("Contact One", email = "example@email.com"),
-    visitors = listOf(VisitorDto(1234), VisitorDto(9876)),
+      bookingReference = "qq-yy-xx-kk",
+      visitDate = LocalDate.now().plusDays(1),
+      visitTime = LocalTime.of(0, 1),
+      duration = Duration.of(30, ChronoUnit.MINUTES),
+      visitContact = ContactDto("Contact One", email = "example@email.com"),
+      visitors = listOf(VisitorDto(1234), VisitorDto(9876)),
     )
     val bookingReference = visit3.reference
     val visitAdditionalInfo = VisitAdditionalInfo(visit3.reference, "123456")
@@ -521,7 +521,8 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
-    verifyEmailSent(templateId!!, visit, visitAdditionalInfo, templateVars) }
+    verifyEmailSent(templateId!!, visit, visitAdditionalInfo, templateVars)
+  }
 
   private fun verifyEmailSent(templateId: String, visit: VisitDto, visitAdditionalInfo: VisitAdditionalInfo, templateVars: Map<String, Any>) {
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitBookedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitBookedEventEmailTest.kt
@@ -4,6 +4,7 @@ import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -151,6 +152,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
       "phone" to prisonContactDetailsDto.phoneNumber!!,
       "website" to prisonContactDetailsDto.webAddress!!,
     )
+    val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
@@ -159,6 +161,15 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, prisonerSearchResult)
     prisonerContactRegisterMockServer.stubGetPrisonersSocialContacts(visit.prisonerId, prisonerContactsResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        visit.visitContact.email,
+        templateVars,
+        visitAdditionalInfo.eventAuditId,
+      ),
+    ).thenReturn(notificationClientResponse)
+    visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
@@ -172,6 +183,9 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
         visitAdditionalInfo.eventAuditId,
       )
     }
+    await untilAsserted {
+      verify(visitSchedulerService, times(1)).createNotifyNotification(any())
+    }
   }
 
   @Test
@@ -181,15 +195,6 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     val visitAdditionalInfo = VisitAdditionalInfo(visit3.reference, "123456")
     val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
-
-    // When
-    domainEventListenerService.onDomainEvent(jsonSqsMessage)
-    visitSchedulerMockServer.stubGetVisit(bookingReference, visit3)
-    prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
-    prisonerOffenderSearchMockServer.stubGetPrisoner(visit3.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubGetPrisonersSocialContacts(visit3.prisonerId, prisonerContactsResult)
-    prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
-
     val visitDate = visit3.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_BOOKING.name]
@@ -210,6 +215,24 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
       "phone" to prisonContactDetailsDto.phoneNumber!!,
       "website" to prisonContactDetailsDto.webAddress!!,
     )
+    val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
+
+    // When
+    domainEventListenerService.onDomainEvent(jsonSqsMessage)
+    visitSchedulerMockServer.stubGetVisit(bookingReference, visit3)
+    prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
+    prisonerOffenderSearchMockServer.stubGetPrisoner(visit3.prisonerId, prisonerSearchResult)
+    prisonerContactRegisterMockServer.stubGetPrisonersSocialContacts(visit3.prisonerId, prisonerContactsResult)
+    prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        visit.visitContact.email,
+        templateVars,
+        visitAdditionalInfo.eventAuditId,
+      ),
+    ).thenReturn(notificationClientResponse)
+    visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
@@ -223,6 +246,9 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
         visitAdditionalInfo.eventAuditId,
       )
     }
+    await untilAsserted {
+      verify(visitSchedulerService, times(1)).createNotifyNotification(any())
+    }
   }
 
   @Test
@@ -232,15 +258,6 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     val visitAdditionalInfo = VisitAdditionalInfo(visit2.reference, "123456")
     val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
-
-    // When
-    domainEventListenerService.onDomainEvent(jsonSqsMessage)
-    visitSchedulerMockServer.stubGetVisit(bookingReference, visit2)
-    prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
-    prisonerOffenderSearchMockServer.stubGetPrisoner(visit2.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubGetPrisonersSocialContacts(visit2.prisonerId, prisonerContactsResult)
-    prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
-
     val visitDate = visit2.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_BOOKING.name]
@@ -261,6 +278,24 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
       "phone" to prisonContactDetailsDto.phoneNumber!!,
       "website" to prisonContactDetailsDto.webAddress!!,
     )
+    val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
+
+    // When
+    domainEventListenerService.onDomainEvent(jsonSqsMessage)
+    visitSchedulerMockServer.stubGetVisit(bookingReference, visit2)
+    prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
+    prisonerOffenderSearchMockServer.stubGetPrisoner(visit2.prisonerId, prisonerSearchResult)
+    prisonerContactRegisterMockServer.stubGetPrisonersSocialContacts(visit2.prisonerId, prisonerContactsResult)
+    prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        visit.visitContact.email,
+        templateVars,
+        visitAdditionalInfo.eventAuditId,
+      ),
+    ).thenReturn(notificationClientResponse)
+    visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
@@ -273,6 +308,9 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
         templateVars,
         visitAdditionalInfo.eventAuditId,
       )
+    }
+    await untilAsserted {
+      verify(visitSchedulerService, times(1)).createNotifyNotification(any())
     }
   }
 
@@ -293,6 +331,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendEmail(any(), any(), any()) }
+    await untilAsserted { verify(visitSchedulerService, times(0)).createNotifyNotification(any()) }
   }
 
   @Test
@@ -312,6 +351,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendEmail(any(), any(), any()) }
+    await untilAsserted { verify(visitSchedulerService, times(0)).createNotifyNotification(any()) }
   }
 
   @Test
@@ -331,6 +371,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendEmail(any(), any(), any()) }
+    await untilAsserted { verify(visitSchedulerService, times(0)).createNotifyNotification(any()) }
   }
 
   @Test
@@ -362,6 +403,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
       "phone" to prisonContactDetailsDto.phoneNumber!!,
       "website" to prisonContactDetailsDto.webAddress!!,
     )
+    val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
@@ -370,6 +412,15 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     prisonerOffenderSearchMockServer.stubGetPrisoner(singleDigitDateVisit.prisonerId, prisonerSearchResult)
     prisonerContactRegisterMockServer.stubGetPrisonersSocialContacts(singleDigitDateVisit.prisonerId, prisonerContactsResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        visit.visitContact.email,
+        templateVars,
+        visitAdditionalInfo.eventAuditId,
+      ),
+    ).thenReturn(notificationClientResponse)
+    visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
@@ -382,6 +433,9 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
         templateVars,
         visitAdditionalInfo.eventAuditId,
       )
+    }
+    await untilAsserted {
+      verify(visitSchedulerService, times(1)).createNotifyNotification(any())
     }
   }
 
@@ -416,6 +470,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
       "phone" to prisonContactDetailsDto.phoneNumber!!,
       "website" to prisonContactDetailsDto.webAddress!!,
     )
+    val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
@@ -424,6 +479,15 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     prisonerOffenderSearchMockServer.stubGetPrisoner(visitWithOneVisitor.prisonerId, prisonerSearchResult)
     prisonerContactRegisterMockServer.stubGetPrisonersSocialContacts(visitWithOneVisitor.prisonerId, prisonerContactsResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        visit.visitContact.email,
+        templateVars,
+        visitAdditionalInfo.eventAuditId,
+      ),
+    ).thenReturn(notificationClientResponse)
+    visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
@@ -436,6 +500,9 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
         templateVars,
         visitAdditionalInfo.eventAuditId,
       )
+    }
+    await untilAsserted {
+      verify(visitSchedulerService, times(1)).createNotifyNotification(any())
     }
   }
 
@@ -467,6 +534,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
       "phone" to prisonContactDetailsDto.phoneNumber!!,
       "website" to prisonContactDetailsDto.webAddress!!,
     )
+    val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
@@ -475,6 +543,15 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, prisonerSearchResult)
     prisonerContactRegisterMockServer.stubGetPrisonersSocialContacts(visit.prisonerId, null)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        visit.visitContact.email,
+        templateVars,
+        visitAdditionalInfo.eventAuditId,
+      ),
+    ).thenReturn(notificationClientResponse)
+    visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
@@ -487,6 +564,9 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
         templateVars,
         visitAdditionalInfo.eventAuditId,
       )
+    }
+    await untilAsserted {
+      verify(visitSchedulerService, times(1)).createNotifyNotification(any())
     }
   }
 
@@ -519,6 +599,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
       "phone" to prisonContactDetailsDto.phoneNumber!!,
       "website" to prisonContactDetailsDto.webAddress!!,
     )
+    val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
@@ -527,6 +608,15 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, null)
     prisonerContactRegisterMockServer.stubGetPrisonersSocialContacts(visit.prisonerId, prisonerContactsResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        visit.visitContact.email,
+        templateVars,
+        visitAdditionalInfo.eventAuditId,
+      ),
+    ).thenReturn(notificationClientResponse)
+    visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
@@ -539,6 +629,9 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
         templateVars,
         visitAdditionalInfo.eventAuditId,
       )
+    }
+    await untilAsserted {
+      verify(visitSchedulerService, times(1)).createNotifyNotification(any())
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitCancelledEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitCancelledEventEmailTest.kt
@@ -4,6 +4,7 @@ import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -58,6 +59,7 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
 
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_CANCELLED.name]
     val templateVars = createTemplateVars(visit)
+    val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
@@ -65,6 +67,15 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, prisonerSearchResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        visit.visitContact.email,
+        templateVars,
+        visitAdditionalInfo.eventAuditId,
+      ),
+    ).thenReturn(notificationClientResponse)
+    visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
     verifyEmailSent(templateId!!, visit, visitAdditionalInfo, templateVars)
@@ -89,12 +100,23 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_CANCELLED.name]
     val templateVars = createTemplateVars(singleDigitDateVisit)
 
+    val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
+
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
     visitSchedulerMockServer.stubGetVisit(singleDigitDateVisit.reference, singleDigitDateVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(singleDigitDateVisit.prisonerId, prisonerSearchResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        visit.visitContact.email,
+        templateVars,
+        visitAdditionalInfo.eventAuditId,
+      ),
+    ).thenReturn(notificationClientResponse)
+    visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
     verifyEmailSent(templateId!!, singleDigitDateVisit, visitAdditionalInfo, templateVars)
@@ -119,12 +141,23 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_CANCELLED_BY_PRISON.name]
     val templateVars = createTemplateVars(cancelledByPrisonVisit, phone = GOV_UK_PRISON_PAGE, webAddress = GOV_UK_PRISON_PAGE)
 
+    val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
+
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
     visitSchedulerMockServer.stubGetVisit(cancelledByPrisonVisit.reference, cancelledByPrisonVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(cancelledByPrisonVisit.prisonerId, prisonerSearchResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, null)
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        visit.visitContact.email,
+        templateVars,
+        visitAdditionalInfo.eventAuditId,
+      ),
+    ).thenReturn(notificationClientResponse)
+    visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
     verifyEmailSent(templateId!!, cancelledByPrisonVisit, visitAdditionalInfo, templateVars)
@@ -149,12 +182,23 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_CANCELLED_BY_PRISONER.name]
     val templateVars = createTemplateVars(cancelledByPrisonerVisit)
 
+    val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
+
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
     visitSchedulerMockServer.stubGetVisit(cancelledByPrisonerVisit.reference, cancelledByPrisonerVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(cancelledByPrisonerVisit.prisonerId, prisonerSearchResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        visit.visitContact.email,
+        templateVars,
+        visitAdditionalInfo.eventAuditId,
+      ),
+    ).thenReturn(notificationClientResponse)
+    visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
     verifyEmailSent(templateId!!, cancelledByPrisonerVisit, visitAdditionalInfo, templateVars)
@@ -186,6 +230,7 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
     await untilAsserted { verify(emailSenderService, times(1)).sendEmail(any(), any(), any()) }
     await untilAsserted { verify(notificationClient, times(0)).sendEmail(any(), any(), any(), any()) }
+    await untilAsserted { verify(visitSchedulerService, times(0)).createNotifyNotification(any()) }
   }
 
   @Test
@@ -198,12 +243,23 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_CANCELLED.name]
     val templateVars = createTemplateVars(visit, openingSentence = "visit to the prison", prisoner = "the prisoner")
 
+    val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
+
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
     visitSchedulerMockServer.stubGetVisit(visit.reference, visit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, null)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        visit.visitContact.email,
+        templateVars,
+        visitAdditionalInfo.eventAuditId,
+      ),
+    ).thenReturn(notificationClientResponse)
+    visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
     verifyEmailSent(templateId!!, visit, visitAdditionalInfo, templateVars)
@@ -303,6 +359,9 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
         visitAdditionalInfo.eventAuditId,
       )
     }
+    await untilAsserted {
+      verify(visitSchedulerService, times(1)).createNotifyNotification(any())
+    }
   }
 
   private fun verifyEmailNotSent(visitAdditionalInfo: VisitAdditionalInfo) {
@@ -310,5 +369,6 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendEmail(any(), any(), any()) }
     await untilAsserted { verify(notificationClient, times(0)).sendEmail(any(), any(), any(), any()) }
+    await untilAsserted { verify(visitSchedulerService, times(0)).createNotifyNotification(any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitCancelledEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitCancelledEventEmailTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateN
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.VisitEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.EventsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.EmailSenderService.Companion.GOV_UK_PRISON_PAGE
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitAdditionalInfo
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.PRISON_VISIT_CANCELLED
 import java.time.Duration
 import java.time.LocalDate
@@ -51,7 +52,8 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
   @Test
   fun `when visit cancelled message is received then cancelled email is sent`() {
     // Given
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visit.reference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_CANCELLED.name]
@@ -65,7 +67,7 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
 
     // Then
-    verifyEmailSent(templateId!!, visit, templateVars)
+    verifyEmailSent(templateId!!, visit, visitAdditionalInfo, templateVars)
   }
 
   @Test
@@ -80,7 +82,8 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
       visitors = listOf(VisitorDto(1234), VisitorDto(9876)),
       outcomeStatus = "VISITOR_CANCELLED",
     )
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(singleDigitDateVisit.reference))
+    val visitAdditionalInfo = VisitAdditionalInfo(singleDigitDateVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_CANCELLED.name]
@@ -94,7 +97,7 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
 
     // Then
-    verifyEmailSent(templateId!!, singleDigitDateVisit, templateVars)
+    verifyEmailSent(templateId!!, singleDigitDateVisit, visitAdditionalInfo, templateVars)
   }
 
   @Test
@@ -109,7 +112,8 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
       visitors = listOf(VisitorDto(1234), VisitorDto(9876)),
       outcomeStatus = "ESTABLISHMENT_CANCELLED",
     )
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(cancelledByPrisonVisit.reference))
+    val visitAdditionalInfo = VisitAdditionalInfo(cancelledByPrisonVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_CANCELLED_BY_PRISON.name]
@@ -123,7 +127,7 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, null)
 
     // Then
-    verifyEmailSent(templateId!!, cancelledByPrisonVisit, templateVars)
+    verifyEmailSent(templateId!!, cancelledByPrisonVisit, visitAdditionalInfo, templateVars)
   }
 
   @Test
@@ -138,7 +142,8 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
       visitors = listOf(VisitorDto(1234), VisitorDto(9876)),
       outcomeStatus = "PRISONER_CANCELLED",
     )
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(cancelledByPrisonerVisit.reference))
+    val visitAdditionalInfo = VisitAdditionalInfo(cancelledByPrisonerVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_CANCELLED_BY_PRISONER.name]
@@ -152,7 +157,7 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
 
     // Then
-    verifyEmailSent(templateId!!, cancelledByPrisonerVisit, templateVars)
+    verifyEmailSent(templateId!!, cancelledByPrisonerVisit, visitAdditionalInfo, templateVars)
   }
 
   @Test
@@ -167,7 +172,9 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
       visitors = listOf(VisitorDto(1234), VisitorDto(9876)),
       outcomeStatus = "NOT_RECORDED",
     )
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(unsupportedCancelledTypeVisit.reference))
+    val visitAdditionalInfo = VisitAdditionalInfo(unsupportedCancelledTypeVisit.reference, "123456")
+
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -176,15 +183,16 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, unsupportedCancelledTypeVisit.reference) }
-    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(any(), any()) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(any(), any(), any()) }
     await untilAsserted { verify(notificationClient, times(0)).sendEmail(any(), any(), any(), any()) }
   }
 
   @Test
   fun `when visit cancelled message is received and prisoner-search returns an error, cancelled email is still sent`() {
     // Given
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visit.reference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = templatesConfig.emailTemplates[EmailTemplateNames.VISIT_CANCELLED.name]
@@ -198,14 +206,15 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
 
     // Then
-    verifyEmailSent(templateId!!, visit, templateVars)
+    verifyEmailSent(templateId!!, visit, visitAdditionalInfo, templateVars)
   }
 
   @Test
   fun `when visit cancelled message is received but the visit could not be found then cancelled email is not sent`() {
     // Given
     val bookingReference = visit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -213,7 +222,7 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, null, HttpStatus.NOT_FOUND)
 
     // Then
-    verifyEmailNotSent(visit.reference)
+    verifyEmailNotSent(visitAdditionalInfo)
   }
 
   @Test
@@ -228,7 +237,8 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
       visitors = listOf(VisitorDto(1234), VisitorDto(9876)),
       outcomeStatus = "VISITOR_CANCELLED",
     )
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(pastDatedVisit.reference))
+    val visitAdditionalInfo = VisitAdditionalInfo(pastDatedVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -236,7 +246,7 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(pastDatedVisit.reference, null, HttpStatus.NOT_FOUND)
 
     // Then
-    verifyEmailNotSent(pastDatedVisit.reference)
+    verifyEmailNotSent(visitAdditionalInfo)
   }
 
   @Test
@@ -251,7 +261,8 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
       visitors = listOf(VisitorDto(1234), VisitorDto(9876)),
       outcomeStatus = "VISITOR_CANCELLED",
     )
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(noContactVisit.reference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -259,7 +270,7 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(noContactVisit.reference, null, HttpStatus.NOT_FOUND)
 
     // Then
-    verifyEmailNotSent(noContactVisit.reference)
+    verifyEmailNotSent(visitAdditionalInfo)
   }
 
   private fun createTemplateVars(visit: VisitDto, openingSentence: String? = "visit to see $prisonerSearchResult", prisoner: String? = prisonerSearchResult.toString(), phone: String? = prisonContactDetailsDto.phoneNumber, webAddress: String? = prisonContactDetailsDto.webAddress): Map<String, Any> {
@@ -280,24 +291,24 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     )
   }
 
-  private fun verifyEmailSent(templateId: String, visit: VisitDto, templateVars: Map<String, Any>) {
+  private fun verifyEmailSent(templateId: String, visit: VisitDto, visitAdditionalInfo: VisitAdditionalInfo, templateVars: Map<String, Any>) {
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visit.reference) }
-    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visit, VisitEventType.CANCELLED) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(1)).sendEmail(visit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendEmail(
         templateId,
         visit.visitContact.email,
         templateVars,
-        visit.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
 
-  private fun verifyEmailNotSent(visitReference: String) {
+  private fun verifyEmailNotSent(visitAdditionalInfo: VisitAdditionalInfo) {
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitReference) }
-    await untilAsserted { verify(emailSenderService, times(0)).sendEmail(any(), any()) }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(0)).sendEmail(any(), any(), any()) }
     await untilAsserted { verify(notificationClient, times(0)).sendEmail(any(), any(), any(), any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitBookedEventSmsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitBookedEventSmsTest.kt
@@ -122,13 +122,13 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.BOOKED) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
         visit.visitContact.telephone,
         templateVars,
-        visit.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
@@ -160,13 +160,13 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit3, VisitEventType.BOOKED) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit3, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
         visit3.visitContact.telephone,
         templateVars,
-        visit3.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
@@ -198,13 +198,13 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit2, VisitEventType.BOOKED) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit2, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
         visit2.visitContact.telephone,
         templateVars,
-        visit2.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
@@ -225,7 +225,7 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
   }
 
   @Test
@@ -244,7 +244,7 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
   }
 
   @Test
@@ -263,7 +263,7 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
   }
 
   @Test
@@ -295,13 +295,13 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(singleDigitDateVisit, VisitEventType.BOOKED) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendSms(singleDigitDateVisit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
         singleDigitDateVisit.visitContact.telephone,
         templateVars,
-        singleDigitDateVisit.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitCancelledEventSmsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitCancelledEventSmsTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNames
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.VisitEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.EventsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitAdditionalInfo
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.PRISON_VISIT_CANCELLED
 import java.time.Duration
 import java.time.LocalDate
@@ -111,7 +112,8 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit cancelled message is received then cancel message is sent`() {
     // Given
     val bookingReference = visit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson("bi-vn-wn-ml"))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
     val visitDate = visit.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
@@ -134,7 +136,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, "bi-vn-wn-ml") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.CANCELLED) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
@@ -150,7 +152,8 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit cancelled message is received then cancel message is sent with the right time format  when start time minutes is 00`() {
     // Given
     val bookingReference = visit3.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson("zz-yy-xx-kk"))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit3.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
     val visitDate = visit3.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
@@ -173,7 +176,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, "zz-yy-xx-kk") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit3, VisitEventType.CANCELLED) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
@@ -189,7 +192,8 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit cancelled message is received then cancel message is sent with the right time format  when start time minutes is 01`() {
     // Given
     val bookingReference = visit4.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson("qq-yy-xx-kk"))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit4.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
     val visitDate = visit4.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
@@ -212,7 +216,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, "qq-yy-xx-kk") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit4, VisitEventType.CANCELLED) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
@@ -228,7 +232,8 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit cancelled message is received but no prison contact number then cancel message is sent`() {
     // Given
     val bookingReference = visit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson("bi-vn-wn-ml"))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
     val visitDate = visit.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
@@ -250,7 +255,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, "bi-vn-wn-ml") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.CANCELLED) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
@@ -266,7 +271,8 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit cancelled message is received but the visit could not be found then cancel message is not sent`() {
     // Given
     val bookingReference = visit2.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit2.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -276,7 +282,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, "aa-xx-wn-ml") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any()) }
   }
 
@@ -284,7 +290,8 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit cancelled message is received but the visit is in the past then cancel message is not sent`() {
     // Given
     val bookingReference = pastDatedVisit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(pastDatedVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -294,7 +301,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, "aa-bb-cc-dd") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any()) }
   }
 
@@ -302,7 +309,8 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit cancelled message is received but no visit contact then cancel message is not sent`() {
     // Given
     val bookingReference = noContactVisit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(noContactVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -312,7 +320,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, "bb-cc-dd-zz") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any()) }
   }
 
@@ -320,7 +328,8 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
   fun `when single digit visit date cancelled then message is sent out with the right visit date format`() {
     // Given
     val bookingReference = singleDigitDateVisit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(singleDigitDateVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
     val visitYear = singleDigitDateVisit.startTimestamp.toLocalDate().year
     // expected visit date should not be 2 digits
@@ -343,7 +352,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, "bb-cc-dd-xd") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(1)).sendSms(singleDigitDateVisit, VisitEventType.CANCELLED) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitUpdateEventSmsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitUpdateEventSmsTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNames
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.VisitEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.EventsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitAdditionalInfo
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.PRISON_VISIT_CHANGED
 import java.time.Duration
 import java.time.LocalDate
@@ -101,7 +102,8 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit updated message is received then update message is sent`() {
     // Given
     val bookingReference = visit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
     val visitDate = visit.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
@@ -122,7 +124,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, "bi-vn-wn-ml") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.UPDATED) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
@@ -138,7 +140,8 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit updated message is received then update message is sent with th right time format when start time minutes is 00`() {
     // Given
     val bookingReference = visit2.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit2.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
     val visitDate = visit2.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
@@ -159,7 +162,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, "zz-yy-xx-kk") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit2, VisitEventType.UPDATED) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
@@ -175,7 +178,8 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit updated message is received then update message is sent with th right time format when start time minutes is 01`() {
     // Given
     val bookingReference = visit3.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit3.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
     val visitDate = visit3.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
@@ -196,7 +200,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, "qq-yy-xx-kk") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit3, VisitEventType.UPDATED) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
@@ -212,7 +216,8 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit updated message is received but the visit could not be found then update message is not sent`() {
     // Given
     val bookingReference = visit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -222,7 +227,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, "bi-vn-wn-ml") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any()) }
   }
 
@@ -230,7 +235,8 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit updated message is received but the visit is in the past then update message is not sent`() {
     // Given
     val bookingReference = pastDatedVisit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(pastDatedVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -240,7 +246,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, "aa-bb-cc-dd") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any()) }
   }
 
@@ -248,7 +254,8 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit updated message is received but no visit contact then update message is not sent`() {
     // Given
     val bookingReference = noContactVisit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(noContactVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     // When
@@ -258,7 +265,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, "bb-cc-dd-zz") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any()) }
   }
 
@@ -266,7 +273,8 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
   fun `when visit date updated to a single digit date then message is sent out with the right visit date format`() {
     // Given
     val bookingReference = singleDigitDateVisit.reference
-    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(bookingReference))
+    val visitAdditionalInfo = VisitAdditionalInfo(singleDigitDateVisit.reference, "123456")
+    val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
     val visitYear = singleDigitDateVisit.startTimestamp.toLocalDate().year
     // expected visit date should not be 2 digits
@@ -288,7 +296,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
 
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, "bb-cc-dd-xd") }
+    await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
     await untilAsserted { verify(smsSenderService, times(1)).sendSms(singleDigitDateVisit, VisitEventType.UPDATED) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitUpdateEventSmsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitUpdateEventSmsTest.kt
@@ -125,13 +125,13 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.UPDATED) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
         visit.visitContact.telephone,
         templateVars,
-        visit.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
@@ -163,13 +163,13 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit2, VisitEventType.UPDATED) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit2, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
         visit2.visitContact.telephone,
         templateVars,
-        visit2.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
@@ -201,13 +201,13 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit3, VisitEventType.UPDATED) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit3, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
         visit3.visitContact.telephone,
         templateVars,
-        visit3.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }
@@ -228,7 +228,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
   }
 
   @Test
@@ -247,7 +247,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
   }
 
   @Test
@@ -266,7 +266,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
   }
 
   @Test
@@ -297,13 +297,13 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(notificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(singleDigitDateVisit, VisitEventType.UPDATED) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendSms(singleDigitDateVisit, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
         singleDigitDateVisit.visitContact.telephone,
         templateVars,
-        singleDigitDateVisit.reference,
+        visitAdditionalInfo.eventAuditId,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/mock/VisitSchedulerMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/mock/VisitSchedulerMockServer.kt
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.post
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -23,6 +24,14 @@ class VisitSchedulerMockServer(@Autowired private val objectMapper: ObjectMapper
               .withBody(getJsonString(visitDto))
           },
         ),
+    )
+  }
+
+  fun stubCreateNotifyNotification(httpStatus: HttpStatus) {
+    val responseBuilder = createJsonResponseBuilder()
+    stubFor(
+      post("/visits/notify/create")
+        .willReturn(responseBuilder.withStatus(httpStatus.value())),
     )
   }
 


### PR DESCRIPTION
## What does this PR do?
This PR adds part 1 of a 2 part features to the notification service.
1. Calls to the visit-scheduler to store a notification history for all notifications sent

As part of this change, both email and sms sender services will capture the response from Gov Notify and make a call to the visit-scheduler to store a "paper trail" of the notification. On the visit-scheduler side, it will be saved into a new table and eventually overwritten by the final update from the "notify callback" (part-2).

## Whats next?
Part2 (another PR to come): Processes callback from gov notify to store final outcome of notification

## JIRA Ticket
https://dsdmoj.atlassian.net/browse/VB-4902