### PR TITLE
Vb 4902 [Part2] - Implement gov notify callback

### DIFF
--- a/helm_deploy/hmpps-notifications-alerts-vsip/values.yaml
+++ b/helm_deploy/hmpps-notifications-alerts-vsip/values.yaml
@@ -36,6 +36,7 @@ generic-service:
       SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
       SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
       NOTIFY_API_KEY: "NOTIFY_API_KEY"
+      NOTIFY_CALLBACK_TOKEN: "NOTIFY_CALLBACK_TOKEN"
     hmpps-domain-events-topic:
       HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
     sqs-prison-visits-notification-alerts-secret:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/client/VisitSchedulerClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/client/VisitSchedulerClient.kt
@@ -58,7 +58,7 @@ class VisitSchedulerClient(
 
   fun processNotifyCallbackNotification(notifyCallbackNotificationDto: NotifyCallbackNotificationDto) {
     webClient.post()
-      .uri("/visits/notify/create")
+      .uri("/visits/notify/callback")
       .body(BodyInserters.fromValue(notifyCallbackNotificationDto))
       .accept(MediaType.APPLICATION_JSON)
       .retrieve()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/client/VisitSchedulerClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/client/VisitSchedulerClient.kt
@@ -10,6 +10,7 @@ import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.NotifyCallbackNotificationDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.NotifyCreateNotificationDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.ClientUtils.Companion.isNotFoundError
@@ -46,12 +47,23 @@ class VisitSchedulerClient(
 
   fun createNotifyNotification(notifyCreateNotificationDto: NotifyCreateNotificationDto) {
     webClient.post()
-      .uri("visits/notify/create")
+      .uri("/visits/notify/create")
       .body(BodyInserters.fromValue(notifyCreateNotificationDto))
       .accept(MediaType.APPLICATION_JSON)
       .retrieve()
       .toBodilessEntity()
       .doOnError { e -> LOG.error("Could not createNotifyNotification :", e) }
+      .block(apiTimeout)
+  }
+
+  fun processNotifyCallbackNotification(notifyCallbackNotificationDto: NotifyCallbackNotificationDto) {
+    webClient.post()
+      .uri("/visits/notify/create")
+      .body(BodyInserters.fromValue(notifyCallbackNotificationDto))
+      .accept(MediaType.APPLICATION_JSON)
+      .retrieve()
+      .toBodilessEntity()
+      .doOnError { e -> LOG.error("Could not processNotifyCallbackNotification :", e) }
       .block(apiTimeout)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/config/HmppsNotificationsAlertsVsipExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/config/HmppsNotificationsAlertsVsipExceptionHandler.kt
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.client.HttpClientErrorException.Unauthorized
+import software.amazon.awssdk.http.HttpStatusCode.UNAUTHORIZED
 
 @RestControllerAdvice
 class HmppsNotificationsAlertsVsipExceptionHandler {
@@ -20,6 +22,20 @@ class HmppsNotificationsAlertsVsipExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Validation failure: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(Unauthorized::class)
+  fun handleUnauthorizedException(e: Exception): ResponseEntity<ErrorResponse> {
+    log.info("Unauthorised request made: {}", e.message)
+    return ResponseEntity
+      .status(UNAUTHORIZED)
+      .body(
+        ErrorResponse(
+          status = UNAUTHORIZED,
+          userMessage = "Unauthorised request made: ${e.message}",
           developerMessage = e.message,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/config/HmppsNotificationsAlertsVsipExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/config/HmppsNotificationsAlertsVsipExceptionHandler.kt
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
-import org.springframework.web.client.HttpClientErrorException.Unauthorized
+import org.springframework.web.client.HttpClientErrorException
 import software.amazon.awssdk.http.HttpStatusCode.UNAUTHORIZED
 
 @RestControllerAdvice
@@ -27,7 +27,7 @@ class HmppsNotificationsAlertsVsipExceptionHandler {
       )
   }
 
-  @ExceptionHandler(Unauthorized::class)
+  @ExceptionHandler(HttpClientErrorException::class)
   fun handleUnauthorizedException(e: Exception): ResponseEntity<ErrorResponse> {
     log.info("Unauthorised request made: {}", e.message)
     return ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/config/ResourceServerConfiguration.kt
@@ -20,6 +20,21 @@ import org.springframework.security.web.SecurityFilterChain
 @EnableCaching
 class ResourceServerConfiguration {
 
+  @Bean
+  fun visitNotifyCallbackSecurityFilter(http: HttpSecurity): SecurityFilterChain {
+    http {
+      sessionManagement { sessionCreationPolicy = SessionCreationPolicy.STATELESS }
+      // Can't have CSRF protection as requires session
+      csrf { disable() }
+
+      securityMatcher("/visits/notify/callback")
+      authorizeHttpRequests {
+        authorize("/visits/notify/callback", permitAll)
+      }
+    }
+    return http.build()
+  }
+
   @Throws(Exception::class)
   @Bean
   fun filterChain(http: HttpSecurity): SecurityFilterChain {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/controller/GovNotifyCallbackController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/controller/GovNotifyCallbackController.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.notificationsalertsvsip.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.client.HttpClientErrorException
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.NotifyCallbackNotificationDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.VisitSchedulerService
+import java.security.MessageDigest
+
+const val GOV_NOTIFY_CALLBACK: String = "/visits/notify/callback"
+
+@RestController
+@Validated
+@Tag(name = "1. Gov notify callback controller")
+@RequestMapping(name = "Accept callback", produces = [MediaType.APPLICATION_JSON_VALUE])
+class GovNotifyCallbackController(
+  @Value("\${notify.callback-token}") private val govNotifyAccessToken: String,
+  private val visitSchedulerService: VisitSchedulerService,
+) {
+  companion object {
+    val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @PostMapping(GOV_NOTIFY_CALLBACK)
+  @Operation(
+    summary = "Process gov notify callback",
+    description = "Accept and process the gov notify callback for notifications",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Gov notify callback processed",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun processGovNotifyCallback(
+    @RequestHeader("Authorization")
+    authHeader: String?,
+    @RequestBody
+    govNotifyCallbackNotificationDto: NotifyCallbackNotificationDto,
+  ) {
+    val token = authHeader?.removePrefix("Bearer ")
+
+    if (token == null || !isTokenValid(token)) {
+      LOG.error("Received callback with null or invalid token")
+      throw HttpClientErrorException(HttpStatus.UNAUTHORIZED, "Unauthorized access")
+    }
+
+    LOG.info("Received callback with valid token, processing request for event - ${govNotifyCallbackNotificationDto.eventAuditId}")
+    visitSchedulerService.processNotifyCallback(govNotifyCallbackNotificationDto)
+  }
+
+  private fun isTokenValid(providedToken: String): Boolean {
+    // Using MessageDigest to mitigate against timed attacks and other potential attack vectors
+    return MessageDigest.isEqual(providedToken.toByteArray(), govNotifyAccessToken.toByteArray())
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/NotifyCallbackNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/NotifyCallbackNotificationDto.kt
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
+import java.util.*
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Gov Notify Callback Notification")
 data class NotifyCallbackNotificationDto(
   @Schema(description = "The UUID of the notification", required = true)
-  val id: Long,
-  @Schema(description = "The id of the event audit which the notification is linked to", example = "123456", required = true)
+  val id: UUID,
+  @Schema(description = "The id of the event audit which the notification is linked to", required = true)
   @JsonProperty("reference")
   val eventAuditId: Long,
   @Schema(description = "The final status of the notification", required = true)
@@ -21,10 +22,10 @@ data class NotifyCallbackNotificationDto(
   val completedAt: LocalDateTime?,
   @Schema(description = "The timestamp for when gov notify sent the notification", required = false)
   val sentAt: LocalDateTime?,
-  @Schema(description = "The type of the notification", example = "email", required = true)
+  @Schema(description = "The type of the notification", required = true)
   val notificationType: String,
-  @Schema(description = "The id the template used for the notification", example = "email", required = true)
-  val templateId: String,
-  @Schema(description = "The version of the template used for the notification", example = "email", required = true)
-  val templateVersion: String,
+  @Schema(description = "The id the template used for the notification", required = true)
+  val templateId: UUID,
+  @Schema(description = "The version of the template used for the notification", required = true)
+  val templateVersion: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/NotifyCreateNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/NotifyCreateNotificationDto.kt
@@ -18,11 +18,11 @@ data class NotifyCreateNotificationDto(
   val eventAuditId: String,
   @Schema(description = "The timestamp for when the vsip notification service sent the notification to gov notify", required = true)
   val createdAt: LocalDateTime,
-  @Schema(description = "The type of the notification", example = "email", required = true)
+  @Schema(description = "The type of the notification", required = true)
   val notificationType: String,
-  @Schema(description = "The id the template used for the notification", example = "email", required = true)
+  @Schema(description = "The id the template used for the notification", required = true)
   val templateId: UUID,
-  @Schema(description = "The version of the template used for the notification", example = "email", required = true)
+  @Schema(description = "The version of the template used for the notification", required = true)
   val templateVersion: Int,
 ) {
   constructor(sendEmailResponse: SendEmailResponse) : this(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/VisitSchedulerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/VisitSchedulerService.kt
@@ -4,12 +4,13 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.client.VisitSchedulerClient
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.NotifyCallbackNotificationDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.NotifyCreateNotificationDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
 
 @Service
 class VisitSchedulerService(
-  val visitSchedulerClient: VisitSchedulerClient,
+  private val visitSchedulerClient: VisitSchedulerClient,
 ) {
   private companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
@@ -22,5 +23,9 @@ class VisitSchedulerService(
 
   fun createNotifyNotification(notifyCreateNotificationDto: NotifyCreateNotificationDto) {
     visitSchedulerClient.createNotifyNotification(notifyCreateNotificationDto)
+  }
+
+  fun processNotifyCallback(notifyCallbackNotificationDto: NotifyCallbackNotificationDto) {
+    visitSchedulerClient.processNotifyCallbackNotification(notifyCallbackNotificationDto)
   }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -36,5 +36,3 @@ notify:
     enabled: true
   email:
     enabled: true
-
-notify.api.key: dummy-api-key

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,7 @@ hmpps:
 
 notify:
   apikey: ${notify.api.key}
+  callback-token: ${notify.callback.token}
   sms-templates:
     VISIT_BOOKING: 85904166-e539-43f5-9f51-7ba106cc61bd
     VISIT_UPDATE: 386e83ff-5734-4d99-8279-b3eacb7cc8b8

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
@@ -15,6 +15,7 @@ import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import org.springframework.test.web.reactive.server.WebTestClient
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
@@ -92,6 +93,9 @@ abstract class EventsIntegrationTestBase {
       prisonerOffenderSearchMockServer.stop()
     }
   }
+
+  @Autowired
+  lateinit var webTestClient: WebTestClient
 
   @Autowired
   lateinit var domainEventListenerService: DomainEventListenerService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/mock/VisitSchedulerMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/mock/VisitSchedulerMockServer.kt
@@ -35,6 +35,14 @@ class VisitSchedulerMockServer(@Autowired private val objectMapper: ObjectMapper
     )
   }
 
+  fun stubProcessNotifyCallbackNotification(httpStatus: HttpStatus) {
+    val responseBuilder = createJsonResponseBuilder()
+    stubFor(
+      post("/visits/notify/callback")
+        .willReturn(responseBuilder.withStatus(httpStatus.value())),
+    )
+  }
+
   private fun getJsonString(obj: VisitDto): String {
     return objectMapper.writer().writeValueAsString(obj)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/notify/NotifyCallbackTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/notify/NotifyCallbackTest.kt
@@ -1,0 +1,85 @@
+package uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.notify
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType.APPLICATION_JSON
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.NotifyCallbackNotificationDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.EventsIntegrationTestBase
+import java.time.LocalDateTime
+import java.util.*
+
+class NotifyCallbackTest : EventsIntegrationTestBase() {
+  @Test
+  fun `should process callback successfully with valid token`() {
+    // Given
+    val validToken = "test-valid-token"
+    val dto = NotifyCallbackNotificationDto(
+      id = UUID.randomUUID(),
+      eventAuditId = 123456L,
+      status = "delivered",
+      createdAt = LocalDateTime.now().minusDays(2),
+      completedAt = LocalDateTime.now().minusDays(1),
+      sentAt = LocalDateTime.now().minusDays(1),
+      notificationType = "email",
+      templateId = UUID.randomUUID(),
+      templateVersion = 1,
+    )
+
+    visitSchedulerMockServer.stubProcessNotifyCallbackNotification(HttpStatus.OK)
+
+    // Then
+    webTestClient.post()
+      .uri("/visits/notify/callback")
+      .header("Authorization", "Bearer $validToken")
+      .contentType(APPLICATION_JSON)
+      .bodyValue(dto)
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `should return unauthorized when token is null`() {
+    val dto = NotifyCallbackNotificationDto(
+      id = UUID.randomUUID(),
+      eventAuditId = 123456L,
+      status = "delivered",
+      createdAt = LocalDateTime.now().minusDays(2),
+      completedAt = LocalDateTime.now().minusDays(1),
+      sentAt = LocalDateTime.now().minusDays(1),
+      notificationType = "email",
+      templateId = UUID.randomUUID(),
+      templateVersion = 1,
+    )
+
+    webTestClient.post()
+      .uri("/visits/notify/callback")
+      .contentType(APPLICATION_JSON)
+      .bodyValue(dto)
+      .exchange()
+      .expectStatus().isEqualTo(HttpStatus.UNAUTHORIZED)
+  }
+
+  @Test
+  fun `should return unauthorized when token is invalid`() {
+    val invalidToken = "Bearer invalid-token"
+    val dto = NotifyCallbackNotificationDto(
+      id = UUID.randomUUID(),
+      eventAuditId = 123456L,
+      status = "delivered",
+      createdAt = LocalDateTime.now().minusDays(2),
+      completedAt = LocalDateTime.now().minusDays(1),
+      sentAt = LocalDateTime.now().minusDays(1),
+      notificationType = "email",
+      templateId = UUID.randomUUID(),
+      templateVersion = 1,
+    )
+
+    webTestClient.post()
+      .uri("/visits/notify/callback")
+      .header("Authorization", "Bearer $invalidToken")
+      .contentType(APPLICATION_JSON)
+      .bodyValue(dto)
+      .exchange()
+      .expectStatus().isEqualTo(HttpStatus.UNAUTHORIZED)
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -55,3 +55,6 @@ notify:
     enabled: true
   api:
     key: "test"
+  callback:
+    token: "test-valid-token"
+


### PR DESCRIPTION
## What does this PR do?
Adds a controller to handle gov notify callbacks, it confirms the call has come from gov notify by cross checking the token provided in the auth request with one we have stored in a static environment variable. if successful the request will be forwarded to the visit-scheduler.

Also edits configurations for spring security to skip oauth2 jwt verification through hmpps-auth for this endpoint, as gov notify token will not be issued by hmpps-auth we don't need to go through it to verify.

Add coverage of integration tests for new controller.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-4902