### PR TITLE
Test usage of ingress annotation to allow gov notify to call our callback endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,29 @@ workflows:
               ignore:
                 - main
 
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: "preprod"
+          context:
+            - hmpps-common-vars
+            - visit-someone-in-prison-backend-svc-preprod
+          filters:
+            branches:
+              ignore:
+                - main
+          requires:
+            - request-preprod-approval
+      - request-preprod-approval:
+          type: approval
+          requires:
+            - validate
+            - build_docker
+            - helm_lint
+          filters:
+            branches:
+              ignore:
+                - main
+
   security:
     triggers:
       - schedule:

--- a/helm_deploy/hmpps-notifications-alerts-vsip/values.yaml
+++ b/helm_deploy/hmpps-notifications-alerts-vsip/values.yaml
@@ -45,9 +45,6 @@ generic-service:
       HMPPS_SQS_QUEUES_PRISONVISITSNOTIFICATIONALERTS_DLQ_NAME: "sqs_queue_name"
 
   allowlist:
-    gov-notify-1: 52.17.149.153
-    gov-notify-2: 63.33.132.231
-    gov-notify-3: 54.216.159.202
     groups:
       - internal
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -6,6 +6,8 @@ generic-service:
 
   ingress:
     host: hmpps-notifi-alerts-vsip-preprod.prison.service.justice.gov.uk
+    annotations:
+      nginx.ingress.kubernetes.io/server-snippet: location = /visits/notify/callback { allow all; }
 
   env:
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth


### PR DESCRIPTION
## What does this PR do?
- Temp allow circle-ci to deploy to pre-prod
- Remove IP allow list
- Add ingress annotation to allow all traffic to our endpoint