### PR TITLE
No retry on notify create call exception

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/NotificationService.kt
@@ -45,7 +45,13 @@ class NotificationService(
     }
 
     val notification = smsSenderService.sendSms(visit, visitEventType, additionalInfo.eventAuditId)
-    notification?.let { visitSchedulerService.createNotifyNotification(it) }
+    notification?.let {
+      try {
+        visitSchedulerService.createNotifyNotification(it)
+      } catch (e: Exception) {
+        LOG.info("Call to capture sms notification creation on visit-scheduler failed with exception: $e")
+      }
+    }
   }
 
   private fun sendEmailNotificationIfAvailable(visit: VisitDto, visitEventType: VisitEventType, additionalInfo: VisitAdditionalInfo) {
@@ -56,6 +62,12 @@ class NotificationService(
     }
 
     val notification = emailSenderService.sendEmail(visit, visitEventType, additionalInfo.eventAuditId)
-    notification?.let { visitSchedulerService.createNotifyNotification(it) }
+    notification?.let {
+      try {
+        visitSchedulerService.createNotifyNotification(it)
+      } catch (e: Exception) {
+      LOG.info("Call to capture email notification creation on visit-scheduler failed with exception: $e")
+      }
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/NotificationService.kt
@@ -49,6 +49,7 @@ class NotificationService(
       try {
         visitSchedulerService.createNotifyNotification(it)
       } catch (e: Exception) {
+        // TODO: Remove try-catch and convert to publish message 'notification-sent' instead of direct API call.
         LOG.info("Call to capture sms notification creation on visit-scheduler failed with exception: $e")
       }
     }
@@ -66,7 +67,8 @@ class NotificationService(
       try {
         visitSchedulerService.createNotifyNotification(it)
       } catch (e: Exception) {
-      LOG.info("Call to capture email notification creation on visit-scheduler failed with exception: $e")
+        // TODO: Remove try-catch and convert to publish message 'notification-sent' instead of direct API call.
+        LOG.info("Call to capture email notification creation on visit-scheduler failed with exception: $e")
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

If call to save notification creation fails, don't retry. As this
will push the message back onto the queue and the notification will be
repeatedly sent to a user.

This is a temporary fix, it's low risk as a notification being sent will
have a callback from notify to capture if it was sent or not.

In the future this will be moved to publish a message to our hmpps queue
which the visit scheduler will consume and process.