### PR TITLE
VB-5200 - Skip processing of manually created notifications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/controller/GovNotifyCallbackController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/controller/GovNotifyCallbackController.kt
@@ -50,8 +50,12 @@ class GovNotifyCallbackController(
     @RequestBody
     govNotifyCallbackNotificationDto: NotifyCallbackNotificationDto,
   ) {
-    LOG.info("Gov notify callback body - {}", govNotifyCallbackNotificationDto)
-    LOG.info("Received callback with valid token, processing request for event - ${govNotifyCallbackNotificationDto.eventAuditReference}")
-    visitSchedulerService.processNotifyCallback(govNotifyCallbackNotificationDto)
+    govNotifyCallbackNotificationDto.eventAuditReference?.let {
+      LOG.info("Gov notify callback body - {}", govNotifyCallbackNotificationDto)
+      LOG.info("Received callback with valid token, processing request for event - ${govNotifyCallbackNotificationDto.eventAuditReference}")
+      visitSchedulerService.processNotifyCallback(govNotifyCallbackNotificationDto)
+    } ?: {
+      LOG.info("Received callback with a null reference, skipping processing")
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/NotifyCallbackNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/NotifyCallbackNotificationDto.kt
@@ -14,7 +14,7 @@ data class NotifyCallbackNotificationDto(
   val notificationId: UUID,
   @Schema(description = "The id of the event audit which the notification is linked to", required = true)
   @JsonAlias("reference")
-  val eventAuditReference: String,
+  val eventAuditReference: String?,
   @Schema(description = "The final status of the notification", required = true)
   val status: String,
   @Schema(description = "The timestamp for when the vsip notification service sent the notification to gov notify", required = true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/notify/NotifyCallbackTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/notify/NotifyCallbackTest.kt
@@ -1,12 +1,13 @@
 package uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.notify
 
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.verifyNoInteractions
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.NotifyCallbackNotificationDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.EventsIntegrationTestBase
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 
 class NotifyCallbackTest : EventsIntegrationTestBase() {
   @Test
@@ -84,5 +85,34 @@ class NotifyCallbackTest : EventsIntegrationTestBase() {
       .bodyValue(dto)
       .exchange()
       .expectStatus().isEqualTo(HttpStatus.UNAUTHORIZED)
+  }
+
+  @Test
+  fun `should not forward call to visit-scheduler if eventAuditReference is missing (manually generated notifications)`() {
+    // Given
+    val validToken = "test-valid-token"
+    val dto = NotifyCallbackNotificationDto(
+      notificationId = UUID.randomUUID(),
+      eventAuditReference = null,
+      status = "delivered",
+      sentTo = "testemail@example.com",
+      createdAt = LocalDateTime.now().minusDays(2),
+      completedAt = LocalDateTime.now().minusDays(1),
+      sentAt = LocalDateTime.now().minusDays(1),
+      notificationType = "email",
+      templateId = UUID.randomUUID(),
+      templateVersion = 1,
+    )
+
+    // Then
+    webTestClient.post()
+      .uri("/visits/notify/callback")
+      .header("Authorization", "Bearer $validToken")
+      .contentType(APPLICATION_JSON)
+      .bodyValue(dto)
+      .exchange()
+      .expectStatus().isOk
+
+    verifyNoInteractions(visitSchedulerService)
   }
 }


### PR DESCRIPTION
When a notification is created and sent manually by the team, callbacks fail with a 500 error, because the reference field is missing.

This PR updates the code to skip any callback with a null reference.