### PR TITLE
Fix name case for emails

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/prisoner/search/PrisonerSearchResultDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/prisoner/search/PrisonerSearchResultDto.kt
@@ -10,5 +10,6 @@ data class PrisonerSearchResultDto(
   @Schema(description = "Prisoner last name", example = "Smith", required = true)
   val lastName: String,
 ) {
-  override fun toString(): String = "$firstName $lastName"
+  // Takes the full name and converts it from all capitals, to correct format (JOHN SMITH -> John Smith).
+  override fun toString(): String = listOf(firstName, lastName).joinToString(" ") { it.lowercase().replaceFirstChar { char -> char.titlecaseChar() } }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitBookedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitBookedEventEmailTest.kt
@@ -49,7 +49,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
 
     prison = PrisonDto("HEI", "Hewell", true)
 
-    prisonerSearchResult = PrisonerSearchResultDto("Prisoner", "One")
+    prisonerSearchResult = PrisonerSearchResultDto("PRISONER", "ONE")
 
     prisonerContactsResult = listOf(
       PrisonerContactRegistryContactDto("1234", "Visitor", "One", (LocalDate.now().minusYears(30))),


### PR DESCRIPTION
## What does this PR do?
Transforms the all capital name returned from prisoner search, to be correct format. JOHN SMITH -> John Smith.