### PR TITLE
Remove use of the foojay resolver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jre-jammy AS builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-jammy AS builder
 
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,1 @@
 rootProject.name = "hmpps-notifications-alerts-vsip"
-
-plugins {
-  id("org.gradle.toolchains.foojay-resolver-convention") version ("1.0.0")
-}


### PR DESCRIPTION
It was resulting in errors during our build step in Docker. Remove and use JDK image to build the code instead of the jre used for running.