### PR TITLE
Bug fix: VB-5941 - Only include distrinct visitors in emails

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/email/BaseEmailNotificationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/email/BaseEmailNotificationHandler.kt
@@ -78,7 +78,7 @@ abstract class BaseEmailNotificationHandler {
   protected fun getVisitors(visit: VisitDto): List<String> {
     val visitors = prisonerContactRegistryService.getPrisonerContacts(visit)
     return if (visitors.isNotEmpty()) {
-      visitors.map {
+      visitors.distinctBy { it.personId }.map {
         PrisonerVisitorPersonalisationDto(
           firstNameText = it.firstName,
           lastNameText = it.lastName,


### PR DESCRIPTION
sometimes the visitor list can be duplicated due to bad data in nomis. This PR filters out any duplicates by using distinctBy on personId