### PR TITLE
Fix - disable oss index as it no longer allows anonymous APi submissions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ repositories {
 dependencyCheck {
   suppressionFiles.add("dependency-check-suppress-json.xml")
   nvd.datafeedUrl = "file:///opt/vulnz/cache"
+  analyzers.ossIndex.enabled = false
 }
 
 dependencies {


### PR DESCRIPTION
Dear OSS Index User,
We are reaching out to let you know about an important upcoming change to the OSS Index API. In the near future, authentication with an API token will be required to access our primary /apiresources.
This change will affect automated tools and integrations that rely on the API. While the OSS Index website will continue to show basic information to anonymous users, the most useful and complete data will require authentication.

Anonymous (unauthenticated) access will be phased out.

^ Because of this we will disable it.