### PR TITLE
Swap to use new endpoint in prisoner contact registry as original is deprecated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/client/PrisonerContactRegistryClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/client/PrisonerContactRegistryClient.kt
@@ -31,7 +31,7 @@ class PrisonerContactRegistryClient(
       .retrieve()
       .bodyToMono<List<ContactWithOptionalPrisonerRelationshipDto>>()
       .onErrorResume { e ->
-        LOG.error("searchPrisonerContacts error for get request $uri, with exception $e")
+        LOG.error("searchContacts error for get request $uri, with exception $e")
         return@onErrorResume Mono.empty()
       }
       .block(apiTimeout)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/client/PrisonerContactRegistryClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/client/PrisonerContactRegistryClient.kt
@@ -21,12 +21,12 @@ class PrisonerContactRegistryClient(
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun searchPrisonerContacts(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean = false): List<ContactWithOptionalPrisonerRelationshipDto>? {
-    val uri = "/v2/prisoners/$prisonerId/contacts/search"
+  fun searchContacts(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean = false): List<ContactWithOptionalPrisonerRelationshipDto>? {
+    val uri = "/v2/contacts/search"
 
     return webClient.get()
       .uri(uri) {
-        getSearchPrisonerContactsUriBuilder(contactIds, withRestrictions, it).build()
+        getSearchContactsUriBuilder(prisonerId, contactIds, withRestrictions, it).build()
       }
       .retrieve()
       .bodyToMono<List<ContactWithOptionalPrisonerRelationshipDto>>()
@@ -37,8 +37,9 @@ class PrisonerContactRegistryClient(
       .block(apiTimeout)
   }
 
-  private fun getSearchPrisonerContactsUriBuilder(contactIds: List<Long>, withRestrictions: Boolean = false, uriBuilder: UriBuilder): UriBuilder {
+  private fun getSearchContactsUriBuilder(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean = false, uriBuilder: UriBuilder): UriBuilder {
     uriBuilder.queryParam("contactIds", contactIds.joinToString(","))
+    uriBuilder.queryParam("prisonerId", prisonerId)
     uriBuilder.queryParam("withRestrictions", withRestrictions)
     return uriBuilder
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/external/PrisonerContactRegistryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/external/PrisonerContactRegistryService.kt
@@ -15,7 +15,7 @@ class PrisonerContactRegistryService(
   }
 
   fun searchPrisonerContacts(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean = false): List<ContactWithOptionalPrisonerRelationshipDto> {
-    LOG.info("Calling prisoner contact registry searchPrisonerContacts for prisonerId - $prisonerId and contactIds - $contactIds with restrictions - $withRestrictions")
+    LOG.info("Calling prisoner contact registry searchContacts for prisonerId - $prisonerId and contactIds - $contactIds with restrictions - $withRestrictions")
     return prisonerContactRegistryClient.searchContacts(prisonerId = prisonerId, contactIds = contactIds, withRestrictions = withRestrictions) ?: emptyList()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/external/PrisonerContactRegistryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/external/PrisonerContactRegistryService.kt
@@ -16,6 +16,6 @@ class PrisonerContactRegistryService(
 
   fun searchPrisonerContacts(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean = false): List<ContactWithOptionalPrisonerRelationshipDto> {
     LOG.info("Calling prisoner contact registry searchPrisonerContacts for prisonerId - $prisonerId and contactIds - $contactIds with restrictions - $withRestrictions")
-    return prisonerContactRegistryClient.searchPrisonerContacts(prisonerId = prisonerId, contactIds = contactIds, withRestrictions = withRestrictions) ?: emptyList()
+    return prisonerContactRegistryClient.searchContacts(prisonerId = prisonerId, contactIds = contactIds, withRestrictions = withRestrictions) ?: emptyList()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorApprovedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorApprovedEventEmailTest.kt
@@ -50,7 +50,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
     bookerRegistryMockServer.stubGetBooker(bookerReference, bookerInfo)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(prisonerId, listOf(visitorId), false, listOf(contact1))
+    prisonerContactRegisterMockServer.stubSearchContacts(prisonerId, listOf(visitorId), false, listOf(contact1))
 
     // Then
     verifyBookerEmailSent(templateId!!, bookerAdditionalInfo, bookerInfo, VisitorRequestVisitorInfoDto(contact1), templateVars)
@@ -70,7 +70,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
     bookerRegistryMockServer.stubGetBooker(bookerReference, bookerInfo)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(prisonerId, listOf(visitorId), false, emptyList())
+    prisonerContactRegisterMockServer.stubSearchContacts(prisonerId, listOf(visitorId), false, emptyList())
 
     // Then
     verifyBookerEmailNotSent(bookerAdditionalInfo)
@@ -90,7 +90,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
     bookerRegistryMockServer.stubGetBooker(bookerReference, bookerInfo)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(prisonerId, listOf(visitorId), false, null, HttpStatus.INTERNAL_SERVER_ERROR)
+    prisonerContactRegisterMockServer.stubSearchContacts(prisonerId, listOf(visitorId), false, null, HttpStatus.INTERNAL_SERVER_ERROR)
 
     // Then
     verifyBookerEmailNotSent(bookerAdditionalInfo)
@@ -108,7 +108,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
     bookerRegistryMockServer.stubGetBooker(bookerReference, null, HttpStatus.NOT_FOUND)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(prisonerId, listOf(visitorId), false, listOf(contact1))
+    prisonerContactRegisterMockServer.stubSearchContacts(prisonerId, listOf(visitorId), false, listOf(contact1))
 
     // Then
     verifyBookerEmailNotSent(bookerAdditionalInfo)
@@ -126,7 +126,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
     bookerRegistryMockServer.stubGetBooker(bookerReference, null, HttpStatus.INTERNAL_SERVER_ERROR)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(prisonerId, listOf(visitorId), false, listOf(contact1))
+    prisonerContactRegisterMockServer.stubSearchContacts(prisonerId, listOf(visitorId), false, listOf(contact1))
 
     // Then
     verifyBookerEmailNotSent(bookerAdditionalInfo)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitBookedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitBookedEventEmailTest.kt
@@ -99,7 +99,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
+    prisonerContactRegisterMockServer.stubSearchContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
@@ -160,7 +160,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visit3)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit3.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visit3.prisonerId, visit3.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
+    prisonerContactRegisterMockServer.stubSearchContacts(visit3.prisonerId, visit3.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
@@ -221,7 +221,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visit2)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit2.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visit2.prisonerId, visit2.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
+    prisonerContactRegisterMockServer.stubSearchContacts(visit2.prisonerId, visit2.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
@@ -352,7 +352,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, singleDigitDateVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(singleDigitDateVisit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(singleDigitDateVisit.prisonerId, singleDigitDateVisit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
+    prisonerContactRegisterMockServer.stubSearchContacts(singleDigitDateVisit.prisonerId, singleDigitDateVisit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
     Mockito.`when`(
@@ -417,7 +417,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visitWithOneVisitor)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visitWithOneVisitor.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visitWithOneVisitor.prisonerId, visitWithOneVisitor.visitors.map { it.nomisPersonId }, false, listOf(visitor1))
+    prisonerContactRegisterMockServer.stubSearchContacts(visitWithOneVisitor.prisonerId, visitWithOneVisitor.visitors.map { it.nomisPersonId }, false, listOf(visitor1))
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
@@ -468,7 +468,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, null, HttpStatus.INTERNAL_SERVER_ERROR)
+    prisonerContactRegisterMockServer.stubSearchContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, null, HttpStatus.INTERNAL_SERVER_ERROR)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
@@ -522,7 +522,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, null)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
+    prisonerContactRegisterMockServer.stubSearchContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitRequestApprovedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitRequestApprovedEventEmailTest.kt
@@ -89,7 +89,7 @@ class PrisonVisitRequestApprovedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, approvedVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(approvedVisit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(approvedVisit.prisonerId, approvedVisit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
+    prisonerContactRegisterMockServer.stubSearchContacts(approvedVisit.prisonerId, approvedVisit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
@@ -145,7 +145,7 @@ class PrisonVisitRequestApprovedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, autoApprovedVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(autoApprovedVisit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(autoApprovedVisit.prisonerId, autoApprovedVisit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
+    prisonerContactRegisterMockServer.stubSearchContacts(autoApprovedVisit.prisonerId, autoApprovedVisit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitRequestedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitRequestedEventEmailTest.kt
@@ -101,7 +101,7 @@ class PrisonVisitRequestedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
+    prisonerContactRegisterMockServer.stubSearchContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitUpdatedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitUpdatedEventEmailTest.kt
@@ -100,7 +100,7 @@ class PrisonVisitUpdatedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
+    prisonerContactRegisterMockServer.stubSearchContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
@@ -158,7 +158,7 @@ class PrisonVisitUpdatedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visit3)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit3.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visit3.prisonerId, visit3.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
+    prisonerContactRegisterMockServer.stubSearchContacts(visit3.prisonerId, visit3.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
@@ -216,7 +216,7 @@ class PrisonVisitUpdatedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visit2)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit2.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visit2.prisonerId, visit2.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
+    prisonerContactRegisterMockServer.stubSearchContacts(visit2.prisonerId, visit2.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
@@ -345,7 +345,7 @@ class PrisonVisitUpdatedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, singleDigitDateVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(singleDigitDateVisit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(singleDigitDateVisit.prisonerId, singleDigitDateVisit.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
+    prisonerContactRegisterMockServer.stubSearchContacts(singleDigitDateVisit.prisonerId, singleDigitDateVisit.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
@@ -409,7 +409,7 @@ class PrisonVisitUpdatedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visitWithOneVisitor)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visitWithOneVisitor.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visitWithOneVisitor.prisonerId, visitWithOneVisitor.visitors.map { it.nomisPersonId }, false, listOf(visitor1))
+    prisonerContactRegisterMockServer.stubSearchContacts(visitWithOneVisitor.prisonerId, visitWithOneVisitor.visitors.map { it.nomisPersonId }, false, listOf(visitor1))
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
@@ -459,7 +459,7 @@ class PrisonVisitUpdatedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, null, HttpStatus.INTERNAL_SERVER_ERROR)
+    prisonerContactRegisterMockServer.stubSearchContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, null, HttpStatus.INTERNAL_SERVER_ERROR)
 
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
@@ -511,7 +511,7 @@ class PrisonVisitUpdatedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, null)
-    prisonerContactRegisterMockServer.stubSearchPrisonerContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
+    prisonerContactRegisterMockServer.stubSearchContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/mock/PrisonerContactRegistryMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/mock/PrisonerContactRegistryMockServer.kt
@@ -9,7 +9,7 @@ import tools.jackson.databind.ObjectMapper
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.prisoner.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 
 class PrisonerContactRegistryMockServer(private val objectMapper: ObjectMapper) : WireMockServer(8095) {
-  fun stubSearchPrisonerContacts(
+  fun stubSearchContacts(
     prisonerId: String,
     contactIds: List<Long>,
     withRestrictions: Boolean = false,
@@ -19,7 +19,7 @@ class PrisonerContactRegistryMockServer(private val objectMapper: ObjectMapper) 
     val responseBuilder = aResponse()
       .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
 
-    val uri = "/v2/prisoners/$prisonerId/contacts/search?contactIds=${contactIds.joinToString(",")}&withRestrictions=$withRestrictions"
+    val uri = "/v2/contacts/search?contactIds=${contactIds.joinToString(",")}&prisonerId=$prisonerId&withRestrictions=$withRestrictions"
 
     stubFor(
       get(uri)


### PR DESCRIPTION
## What does this PR do?
The format of the URL has changed to make prisonerId optional when looking up contacts. This moves it out of the URL and into the request params.

Update to new endpoint. No functionality change on what is returned