### PR TITLE
VB-4353 - Initial rework

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,5 +10,10 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore: {}
+ignore:
+  SNYK-JAVA-IOOPENTELEMETRY-17280222:
+    - '*':
+        reason: Suppression for baggage limits issue as we use header size limits
+        expires: 2026-07-11T00:00:00.000Z
+        created: 2026-06-11T07:38:00.250Z
 patch: {}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/BookerNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/BookerNotificationService.kt
@@ -5,13 +5,13 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.client.BookerRegistryClient
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.BookerInfoDto
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.VisitorRequestDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.VisitorRequestVisitorInfoDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.prisoner.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.booker.registry.BookerEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external.PrisonerContactRegistryService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorApprovedAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRejectedAdditionalInfo
 
 @Service
 class BookerNotificationService(
@@ -23,7 +23,8 @@ class BookerNotificationService(
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun sendVisitorRequestApprovedEmail(bookerEventType: BookerEventType, additionalInfo: VisitorApprovedAdditionalInfo) {
+  fun sendVisitorRequestApprovedEmail(additionalInfo: VisitorApprovedAdditionalInfo) {
+    val bookerEventType = BookerEventType.VISITOR_APPROVED
     LOG.info("Received call to send approval notification for event type $bookerEventType, additional info - $additionalInfo")
     val bookerDetails = bookerRegistryClient.getBookerByBookerReference(additionalInfo.bookerReference) ?: throw NotFoundException("Booker details not found for reference ${additionalInfo.bookerReference}")
 
@@ -34,12 +35,18 @@ class BookerNotificationService(
       ),
     )
 
-    emailSenderService.sendBookerVisitorEmail(bookerDetails, visitorDetails, BookerEventType.VISITOR_APPROVED)
+    emailSenderService.sendBookerVisitorEmail(bookerDetails, visitorDetails, bookerEventType)
   }
 
-  fun sendVisitorRequestRejectedEmail(bookerEventType: BookerEventType, visitorRequest: VisitorRequestDto) {
-    LOG.info("Received call to send rejection notification for event type $bookerEventType")
+  fun sendVisitorRequestRejectedEmail(additionalInfo: VisitorRejectedAdditionalInfo) {
+    LOG.info("Received call to send rejection notification, additional info - $additionalInfo")
 
+    val visitorRequest = bookerRegistryClient.getVisitorRequestByReference(additionalInfo.requestReference)
+    val bookerEventType = when (visitorRequest.rejectionReason) {
+      "REJECT" -> BookerEventType.VISITOR_REJECTED
+      "ALREADY_LINKED" -> BookerEventType.VISITOR_REJECTED_ALREADY_LINKED
+      else -> throw IllegalStateException("Unexpected rejection reason ${visitorRequest.rejectionReason}")
+    }
     val bookerInfo = BookerInfoDto(reference = visitorRequest.bookerReference, email = visitorRequest.bookerEmail)
     val visitorDetails = VisitorRequestVisitorInfoDto(visitorRequest)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/SmsSenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/SmsSenderService.kt
@@ -21,7 +21,7 @@ class SmsSenderService(
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun sendSms(visit: VisitDto, visitEventType: VisitEventType, eventAuditId: String): NotifyCreateNotificationDto? {
+  fun sendVisitsSms(visit: VisitDto, visitEventType: VisitEventType, eventAuditId: String): NotifyCreateNotificationDto? {
     if (enabled) {
       val sendSmsNotificationDto = handlerFactory.getHandler(visitEventType).handle(visit)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/VisitNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/VisitNotificationService.kt
@@ -57,7 +57,7 @@ class VisitNotificationService(
       return
     }
 
-    val notification = smsSenderService.sendSms(visit, visitEventType, additionalInfo.eventAuditId)
+    val notification = smsSenderService.sendVisitsSms(visit, visitEventType, additionalInfo.eventAuditId)
     notification?.let {
       try {
         visitSchedulerService.createNotifyNotification(it)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/VisitorRequestNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/VisitorRequestNotificationService.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.ev
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRejectedAdditionalInfo
 
 @Service
-class BookerNotificationService(
+class VisitorRequestNotificationService(
   val emailSenderService: EmailSenderService,
   val bookerRegistryClient: BookerRegistryClient,
   val prisonerContactRegistryService: PrisonerContactRegistryService,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorApprovedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorApprovedEventNotifier.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.n
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.BookerNotificationService
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.VisitorRequestNotificationService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorApprovedAdditionalInfo
 
@@ -11,7 +11,7 @@ const val BOOKER_VISITOR_APPROVED = "prison-visit-booker.visitor-approved"
 
 @Component(value = BOOKER_VISITOR_APPROVED)
 class BookerVisitorApprovedEventNotifier(
-  private val bookerNotificationService: BookerNotificationService,
+  private val visitorRequestNotificationService: VisitorRequestNotificationService,
   @param:Qualifier("objectMapper")
   private val objectMapper: ObjectMapper,
 ) : EventNotifier(objectMapper) {
@@ -19,6 +19,6 @@ class BookerVisitorApprovedEventNotifier(
     val visitorApprovedAdditionalInfo: VisitorApprovedAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorApprovedAdditionalInfo::class.java)
     LOG.info("Enter booking event with info : {}", visitorApprovedAdditionalInfo)
 
-    bookerNotificationService.sendVisitorRequestApprovedEmail(visitorApprovedAdditionalInfo)
+    visitorRequestNotificationService.sendVisitorRequestApprovedEmail(visitorApprovedAdditionalInfo)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorApprovedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorApprovedEventNotifier.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.n
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.booker.registry.BookerEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.BookerNotificationService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorApprovedAdditionalInfo
@@ -18,7 +17,8 @@ class BookerVisitorApprovedEventNotifier(
 ) : EventNotifier(objectMapper) {
   override fun processEvent(domainEvent: DomainEvent) {
     val visitorApprovedAdditionalInfo: VisitorApprovedAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorApprovedAdditionalInfo::class.java)
-    LOG.debug("Enter booking event with info : {}", visitorApprovedAdditionalInfo)
-    bookerNotificationService.sendVisitorRequestApprovedEmail(BookerEventType.VISITOR_APPROVED, visitorApprovedAdditionalInfo)
+    LOG.info("Enter booking event with info : {}", visitorApprovedAdditionalInfo)
+
+    bookerNotificationService.sendVisitorRequestApprovedEmail(visitorApprovedAdditionalInfo)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRejectedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRejectedEventNotifier.kt
@@ -3,8 +3,6 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.n
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.client.BookerRegistryClient
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.booker.registry.BookerEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.BookerNotificationService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRejectedAdditionalInfo
@@ -16,20 +14,11 @@ class BookerVisitorRejectedEventNotifier(
   private val bookerNotificationService: BookerNotificationService,
   @param:Qualifier("objectMapper")
   private val objectMapper: ObjectMapper,
-  private val bookerRegistryClient: BookerRegistryClient,
 ) : EventNotifier(objectMapper) {
   override fun processEvent(domainEvent: DomainEvent) {
     val visitorRejectedAdditionalInfo: VisitorRejectedAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorRejectedAdditionalInfo::class.java)
     LOG.info("Enter booking event with info : $visitorRejectedAdditionalInfo")
 
-    val visitorRequest = bookerRegistryClient.getVisitorRequestByReference(visitorRejectedAdditionalInfo.requestReference)
-
-    val eventType: BookerEventType = when (visitorRequest.rejectionReason) {
-      "REJECT" -> BookerEventType.VISITOR_REJECTED
-      "ALREADY_LINKED" -> BookerEventType.VISITOR_REJECTED_ALREADY_LINKED
-      else -> throw IllegalStateException("Unexpected rejection reason ${visitorRequest.rejectionReason}")
-    }
-
-    bookerNotificationService.sendVisitorRequestRejectedEmail(eventType, visitorRequest)
+    bookerNotificationService.sendVisitorRequestRejectedEmail(visitorRejectedAdditionalInfo)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRejectedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRejectedEventNotifier.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.n
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.BookerNotificationService
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.VisitorRequestNotificationService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRejectedAdditionalInfo
 
@@ -11,7 +11,7 @@ const val BOOKER_VISITOR_REJECTED = "prison-visit-booker.visitor-rejected"
 
 @Component(value = BOOKER_VISITOR_REJECTED)
 class BookerVisitorRejectedEventNotifier(
-  private val bookerNotificationService: BookerNotificationService,
+  private val visitorRequestNotificationService: VisitorRequestNotificationService,
   @param:Qualifier("objectMapper")
   private val objectMapper: ObjectMapper,
 ) : EventNotifier(objectMapper) {
@@ -19,6 +19,6 @@ class BookerVisitorRejectedEventNotifier(
     val visitorRejectedAdditionalInfo: VisitorRejectedAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorRejectedAdditionalInfo::class.java)
     LOG.info("Enter booking event with info : $visitorRejectedAdditionalInfo")
 
-    bookerNotificationService.sendVisitorRequestRejectedEmail(visitorRejectedAdditionalInfo)
+    visitorRequestNotificationService.sendVisitorRequestRejectedEmail(visitorRejectedAdditionalInfo)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
@@ -35,7 +35,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.mock.Pri
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.mock.PrisonerContactRegistryMockServer
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.mock.PrisonerOffenderSearchMockServer
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.mock.VisitSchedulerMockServer
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.BookerNotificationService
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.VisitorRequestNotificationService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.DomainEventListenerService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.EmailSenderService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.NotificationTemplateResolver
@@ -125,7 +125,7 @@ abstract class EventsIntegrationTestBase {
   lateinit var visitNotificationService: VisitNotificationService
 
   @MockitoSpyBean
-  lateinit var bookerNotificationService: BookerNotificationService
+  lateinit var visitorRequestNotificationService: VisitorRequestNotificationService
 
   @MockitoSpyBean
   lateinit var smsSenderService: SmsSenderService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
@@ -35,13 +35,13 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.mock.Pri
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.mock.PrisonerContactRegistryMockServer
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.mock.PrisonerOffenderSearchMockServer
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.mock.VisitSchedulerMockServer
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.VisitorRequestNotificationService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.DomainEventListenerService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.EmailSenderService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.NotificationTemplateResolver
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.PRISON_VISITS_NOTIFICATION_ALERTS_QUEUE_CONFIG_KEY
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.SmsSenderService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.VisitNotificationService
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.VisitorRequestNotificationService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external.VisitSchedulerService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.EventFeatureSwitch

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorApprovedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorApprovedEventEmailTest.kt
@@ -167,7 +167,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
 
   private fun verifyBookerEmailSent(templateId: String, additionalInfo: VisitorApprovedAdditionalInfo, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
     await untilAsserted { verify(bookerVisitorApprovedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestApprovedEmail(BookerEventType.VISITOR_APPROVED, additionalInfo) }
+    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestApprovedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(1)).sendBookerVisitorEmail(bookerInfoDto, visitorInfo, BookerEventType.VISITOR_APPROVED) }
 
     await untilAsserted {
@@ -182,7 +182,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
 
   private fun verifyBookerEmailNotSent(additionalInfo: VisitorApprovedAdditionalInfo) {
     await untilAsserted { verify(bookerVisitorApprovedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestApprovedEmail(BookerEventType.VISITOR_APPROVED, additionalInfo) }
+    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestApprovedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendBookerVisitorEmail(any(), any(), any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorApprovedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorApprovedEventEmailTest.kt
@@ -167,7 +167,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
 
   private fun verifyBookerEmailSent(templateId: String, additionalInfo: VisitorApprovedAdditionalInfo, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
     await untilAsserted { verify(bookerVisitorApprovedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestApprovedEmail(additionalInfo) }
+    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestApprovedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(1)).sendBookerVisitorEmail(bookerInfoDto, visitorInfo, BookerEventType.VISITOR_APPROVED) }
 
     await untilAsserted {
@@ -182,7 +182,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
 
   private fun verifyBookerEmailNotSent(additionalInfo: VisitorApprovedAdditionalInfo) {
     await untilAsserted { verify(bookerVisitorApprovedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestApprovedEmail(additionalInfo) }
+    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestApprovedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendBookerVisitorEmail(any(), any(), any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRejectedAlreadyLinkedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRejectedAlreadyLinkedEventEmailTest.kt
@@ -5,7 +5,6 @@ import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
@@ -68,7 +67,7 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
 
     // Then
-    verifyBookerEmailSent(templateId, bookerInfo, VisitorRequestVisitorInfoDto(visitorRequest), templateVars)
+    verifyBookerEmailSent(templateId, bookerAdditionalInfo, bookerInfo, VisitorRequestVisitorInfoDto(visitorRequest), templateVars)
   }
 
   @Test
@@ -85,7 +84,7 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
 
     // Then
-    verifyBookerEmailNotSent()
+    verifyBookerEmailNotSent(bookerAdditionalInfo)
   }
 
   @Test
@@ -102,7 +101,7 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
 
     // Then
-    verifyBookerEmailNotSent()
+    verifyBookerEmailNotSent(bookerAdditionalInfo)
   }
 
   @Test
@@ -151,12 +150,12 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
 
     // Then
-    verifyBookerEmailSent(templateId, bookerInfo, VisitorRequestVisitorInfoDto(visitorRequest), templateVars)
+    verifyBookerEmailSent(templateId, bookerAdditionalInfo, bookerInfo, VisitorRequestVisitorInfoDto(visitorRequest), templateVars)
   }
 
-  private fun verifyBookerEmailSent(templateId: String, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
+  private fun verifyBookerEmailSent(templateId: String, additionalInfo: VisitorRejectedAdditionalInfo, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
     await untilAsserted { verify(bookerVisitorRejectedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestRejectedEmail(eq(BookerEventType.VISITOR_REJECTED_ALREADY_LINKED), any()) }
+    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(1)).sendBookerVisitorEmail(bookerInfoDto, visitorInfo, BookerEventType.VISITOR_REJECTED_ALREADY_LINKED) }
 
     await untilAsserted {
@@ -169,9 +168,9 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
     }
   }
 
-  private fun verifyBookerEmailNotSent() {
+  private fun verifyBookerEmailNotSent(additionalInfo: VisitorRejectedAdditionalInfo) {
     await untilAsserted { verify(bookerVisitorRejectedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(bookerNotificationService, times(0)).sendVisitorRequestRejectedEmail(eq(BookerEventType.VISITOR_REJECTED), any()) }
+    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendBookerVisitorEmail(any(), any(), any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRejectedAlreadyLinkedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRejectedAlreadyLinkedEventEmailTest.kt
@@ -155,7 +155,7 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
 
   private fun verifyBookerEmailSent(templateId: String, additionalInfo: VisitorRejectedAdditionalInfo, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
     await untilAsserted { verify(bookerVisitorRejectedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
+    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(1)).sendBookerVisitorEmail(bookerInfoDto, visitorInfo, BookerEventType.VISITOR_REJECTED_ALREADY_LINKED) }
 
     await untilAsserted {
@@ -170,7 +170,7 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
 
   private fun verifyBookerEmailNotSent(additionalInfo: VisitorRejectedAdditionalInfo) {
     await untilAsserted { verify(bookerVisitorRejectedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
+    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendBookerVisitorEmail(any(), any(), any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRejectedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRejectedEventEmailTest.kt
@@ -5,7 +5,6 @@ import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
@@ -69,7 +68,7 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
 
     // Then
-    verifyBookerEmailSent(templateId, bookerInfo, VisitorRequestVisitorInfoDto(visitorRequest), templateVars)
+    verifyBookerEmailSent(templateId, bookerAdditionalInfo, bookerInfo, VisitorRequestVisitorInfoDto(visitorRequest), templateVars)
   }
 
   @Test
@@ -86,7 +85,7 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
 
     // Then
-    verifyBookerEmailNotSent()
+    verifyBookerEmailNotSent(bookerAdditionalInfo)
   }
 
   @Test
@@ -103,7 +102,7 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
 
     // Then
-    verifyBookerEmailNotSent()
+    verifyBookerEmailNotSent(bookerAdditionalInfo)
   }
 
   @Test
@@ -153,12 +152,12 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
 
     // Then
-    verifyBookerEmailSent(templateId, bookerInfo, VisitorRequestVisitorInfoDto(visitorRequest), templateVars)
+    verifyBookerEmailSent(templateId, bookerAdditionalInfo, bookerInfo, VisitorRequestVisitorInfoDto(visitorRequest), templateVars)
   }
 
-  private fun verifyBookerEmailSent(templateId: String, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
+  private fun verifyBookerEmailSent(templateId: String, additionalInfo: VisitorRejectedAdditionalInfo, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
     await untilAsserted { verify(bookerVisitorRejectedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestRejectedEmail(eq(BookerEventType.VISITOR_REJECTED), any()) }
+    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(1)).sendBookerVisitorEmail(bookerInfoDto, visitorInfo, BookerEventType.VISITOR_REJECTED) }
 
     await untilAsserted {
@@ -171,9 +170,9 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
     }
   }
 
-  private fun verifyBookerEmailNotSent() {
+  private fun verifyBookerEmailNotSent(additionalInfo: VisitorRejectedAdditionalInfo) {
     await untilAsserted { verify(bookerVisitorRejectedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(bookerNotificationService, times(0)).sendVisitorRequestRejectedEmail(eq(BookerEventType.VISITOR_REJECTED), any()) }
+    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendBookerVisitorEmail(any(), any(), any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRejectedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRejectedEventEmailTest.kt
@@ -157,7 +157,7 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
 
   private fun verifyBookerEmailSent(templateId: String, additionalInfo: VisitorRejectedAdditionalInfo, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
     await untilAsserted { verify(bookerVisitorRejectedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
+    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(1)).sendBookerVisitorEmail(bookerInfoDto, visitorInfo, BookerEventType.VISITOR_REJECTED) }
 
     await untilAsserted {
@@ -172,7 +172,7 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
 
   private fun verifyBookerEmailNotSent(additionalInfo: VisitorRejectedAdditionalInfo) {
     await untilAsserted { verify(bookerVisitorRejectedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(bookerNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
+    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendBookerVisitorEmail(any(), any(), any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitBookedEventSmsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitBookedEventSmsTest.kt
@@ -131,7 +131,7 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -169,7 +169,7 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit3, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit3, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -207,7 +207,7 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit2, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit2, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -234,7 +234,7 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -253,7 +253,7 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -282,7 +282,7 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -301,7 +301,7 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -333,7 +333,7 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(singleDigitDateVisit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(singleDigitDateVisit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -372,7 +372,7 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitCancelledEventSmsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitCancelledEventSmsTest.kt
@@ -159,7 +159,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -203,7 +203,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit3, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit3, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -244,7 +244,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit4, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit4, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -284,7 +284,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -311,7 +311,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -330,7 +330,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -349,7 +349,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -382,7 +382,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(singleDigitDateVisit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(singleDigitDateVisit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -420,7 +420,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -472,7 +472,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(rejectedVisit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(rejectedVisit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -535,7 +535,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(rejectedVisit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(rejectedVisit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -588,7 +588,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(rejectedVisit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(rejectedVisit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -638,7 +638,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(rejectedVisit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(rejectedVisit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -689,7 +689,7 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitRequestedEventSmsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitRequestedEventSmsTest.kt
@@ -96,7 +96,7 @@ class PrisonVisitRequestedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -123,7 +123,7 @@ class PrisonVisitRequestedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -142,7 +142,7 @@ class PrisonVisitRequestedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -161,7 +161,7 @@ class PrisonVisitRequestedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -192,7 +192,7 @@ class PrisonVisitRequestedEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitUpdateEventSmsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitUpdateEventSmsTest.kt
@@ -134,7 +134,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -172,7 +172,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit2, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit2, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -210,7 +210,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit3, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit3, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -237,7 +237,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -256,7 +256,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -275,7 +275,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -306,7 +306,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(singleDigitDateVisit, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(singleDigitDateVisit, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
@@ -344,7 +344,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(0)).sendSms(any(), any(), any()) }
+    await untilAsserted { verify(smsSenderService, times(0)).sendVisitsSms(any(), any(), any()) }
   }
 
   @Test
@@ -374,7 +374,7 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendSms(visit, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,


### PR DESCRIPTION
## What does this PR do?
Clean up the event notifiers before beginning work to implement custom "reply-to" emails. Also rename "sendSms" -> "sendVisitsSms" to match other naming conventions.