### PR TITLE
Business logic updates - General clean-up

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/client/BookerRegistryClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/client/BookerRegistryClient.kt
@@ -30,7 +30,7 @@ class BookerRegistryClient(
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun getBookerByBookerReference(bookerReference: String): BookerInfoDto? {
+  fun getBookerByBookerReference(bookerReference: String): BookerInfoDto {
     val uri = GET_BOOKER_BY_BOOKING_REFERENCE.replace("{bookerReference}", bookerReference)
     return webClient.get()
       .uri(uri)
@@ -43,10 +43,10 @@ class BookerRegistryClient(
           Mono.error(e)
         } else {
           logger.error("getBookerByBookerReference NOT_FOUND for get request $uri")
-          return@onErrorResume Mono.empty()
+          Mono.error(e)
         }
       }
-      .block(apiTimeout)
+      .block(apiTimeout) ?: throw IllegalStateException("Get booker request no response for request with reference $bookerReference")
   }
 
   fun getVisitorRequestByReference(visitorRequestReference: String): VisitorRequestDto {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/config/NotifyClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/config/NotifyClientConfiguration.kt
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Configuration
 import uk.gov.service.notify.NotificationClient
 
 @Configuration
-class NotifyConfiguration(@param:Value("\${notify.apikey:}") private val apiKey: String) {
+class NotifyClientConfiguration(@param:Value("\${notify.apikey:}") private val apiKey: String) {
   @Bean
   fun notifyClient(): NotificationClient = NotificationClient(apiKey)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/config/NotifyProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/config/NotifyProperties.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNam
 @Component
 @ConfigurationProperties(prefix = "notify")
 @Validated
-class NotifyConfig {
+class NotifyProperties {
   @NotNull
   var smsTemplates: Map<LanguagePreference, Map<SmsTemplateNames, String>> = emptyMap()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/NotificationTemplateResolver.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/NotificationTemplateResolver.kt
@@ -2,13 +2,13 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.config.NotifyProperties
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateNames
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNames
 
 @Component
-class NotificationTemplateResolver(private val notifyConfig: NotifyConfig) {
+class NotificationTemplateResolver(private val notifyProperties: NotifyProperties) {
 
   companion object {
     private val LOG = LoggerFactory.getLogger(this::class.java)
@@ -18,13 +18,13 @@ class NotificationTemplateResolver(private val notifyConfig: NotifyConfig) {
     template: EmailTemplateNames,
     languagePreference: LanguagePreference = LanguagePreference.EN,
   ): String {
-    val requestedTemplate = notifyConfig.emailTemplates[languagePreference]?.get(template)
+    val requestedTemplate = notifyProperties.emailTemplates[languagePreference]?.get(template)
 
     if (requestedTemplate != null) {
       return requestedTemplate
     }
 
-    val fallbackTemplate = notifyConfig.emailTemplates[LanguagePreference.EN]?.get(template)
+    val fallbackTemplate = notifyProperties.emailTemplates[LanguagePreference.EN]?.get(template)
 
     if (fallbackTemplate != null) {
       LOG.error(
@@ -42,13 +42,13 @@ class NotificationTemplateResolver(private val notifyConfig: NotifyConfig) {
     template: SmsTemplateNames,
     languagePreference: LanguagePreference = LanguagePreference.EN,
   ): String {
-    val requestedTemplate = notifyConfig.smsTemplates[languagePreference]?.get(template)
+    val requestedTemplate = notifyProperties.smsTemplates[languagePreference]?.get(template)
 
     if (requestedTemplate != null) {
       return requestedTemplate
     }
 
-    val fallbackTemplate = notifyConfig.smsTemplates[LanguagePreference.EN]?.get(template)
+    val fallbackTemplate = notifyProperties.smsTemplates[LanguagePreference.EN]?.get(template)
 
     if (fallbackTemplate != null) {
       LOG.error(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/ReplyToEmailResolver.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/ReplyToEmailResolver.kt
@@ -2,12 +2,12 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.config.NotifyProperties
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external.PrisonerSearchService
 
 @Service
 class ReplyToEmailResolver(
-  private val notifyConfig: NotifyConfig,
+  private val notifyProperties: NotifyProperties,
   private val prisonerSearchService: PrisonerSearchService,
 ) {
   companion object {
@@ -28,7 +28,7 @@ class ReplyToEmailResolver(
   }
 
   fun getReplyToEmailIdForPrison(prisonCode: String): String {
-    val replyToEmailId = notifyConfig.replyToEmailIds[prisonCode]
+    val replyToEmailId = notifyProperties.replyToEmailIds[prisonCode]
 
     if (replyToEmailId.isNullOrBlank()) {
       LOG.info("No reply-to email id configured for prison $prisonCode, using default reply-to email id")
@@ -38,7 +38,7 @@ class ReplyToEmailResolver(
     return replyToEmailId
   }
 
-  private fun getDefaultReplyToEmailId(): String = notifyConfig.replyToEmailIds[DEFAULT_REPLY_TO_EMAIL_PRISON_CODE]
+  private fun getDefaultReplyToEmailId(): String = notifyProperties.replyToEmailIds[DEFAULT_REPLY_TO_EMAIL_PRISON_CODE]
     ?.takeIf { it.isNotBlank() }
     ?: throw IllegalStateException("Default reply-to email id must be configured against prison code $DEFAULT_REPLY_TO_EMAIL_PRISON_CODE")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/VisitorRequestNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/VisitorRequestNotificationService.kt
@@ -3,12 +3,12 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.client.BookerRegistryClient
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.BookerInfoDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.VisitorRequestVisitorInfoDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.prisoner.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.booker.registry.BookerEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external.BookerRegistryService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external.PrisonerContactRegistryService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorApprovedAdditionalInfo
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRejectedAdditionalInfo
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.ev
 @Service
 class VisitorRequestNotificationService(
   val emailSenderService: EmailSenderService,
-  val bookerRegistryClient: BookerRegistryClient,
+  val bookerRegistryService: BookerRegistryService,
   val prisonerContactRegistryService: PrisonerContactRegistryService,
   val replyToEmailResolver: ReplyToEmailResolver,
 ) {
@@ -27,7 +27,7 @@ class VisitorRequestNotificationService(
   fun sendVisitorRequestApprovedEmail(additionalInfo: VisitorApprovedAdditionalInfo) {
     val bookerEventType = BookerEventType.VISITOR_APPROVED
     LOG.info("Received call to send approval notification for event type $bookerEventType, additional info - $additionalInfo")
-    val bookerDetails = bookerRegistryClient.getBookerByBookerReference(additionalInfo.bookerReference) ?: throw NotFoundException("Booker details not found for reference ${additionalInfo.bookerReference}")
+    val bookerDetails = bookerRegistryService.getBookerByBookerReference(additionalInfo.bookerReference)
 
     val visitorDetails = VisitorRequestVisitorInfoDto(
       getVisitorContactDetails(
@@ -43,7 +43,7 @@ class VisitorRequestNotificationService(
   fun sendVisitorRequestRejectedEmail(additionalInfo: VisitorRejectedAdditionalInfo) {
     LOG.info("Received call to send rejection notification, additional info - $additionalInfo")
 
-    val visitorRequest = bookerRegistryClient.getVisitorRequestByReference(additionalInfo.requestReference)
+    val visitorRequest = bookerRegistryService.getVisitorRequestByReference(additionalInfo.requestReference)
     val bookerEventType = when (visitorRequest.rejectionReason) {
       "REJECT" -> BookerEventType.VISITOR_REJECTED
       "ALREADY_LINKED" -> BookerEventType.VISITOR_REJECTED_ALREADY_LINKED

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/external/BookerRegistryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/external/BookerRegistryService.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.client.BookerRegistryClient
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.BookerInfoDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.VisitorRequestDto
+
+@Service
+class BookerRegistryService(
+  val bookerRegistryClient: BookerRegistryClient,
+) {
+  private companion object {
+    val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun getBookerByBookerReference(bookerReference: String): BookerInfoDto {
+    LOG.info("BookerRegistryService getBookerByBookerReference called with bookerReference - $bookerReference")
+    return bookerRegistryClient.getBookerByBookerReference(bookerReference)
+  }
+
+  fun getVisitorRequestByReference(visitorRequestReference: String): VisitorRequestDto {
+    LOG.info("BookerRegistryService getVisitorRequestByReference called with visitorRequestReference - $visitorRequestReference")
+    return bookerRegistryClient.getVisitorRequestByReference(visitorRequestReference)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
@@ -21,7 +21,7 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
 import tools.jackson.databind.ObjectMapper
 import tools.jackson.module.kotlin.jacksonObjectMapper
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.config.NotifyProperties
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.ContactDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitExternalSystemDetailsDto
@@ -137,7 +137,7 @@ abstract class EventsIntegrationTestBase {
   lateinit var visitSchedulerService: VisitSchedulerService
 
   @MockitoSpyBean
-  lateinit var notifyConfig: NotifyConfig
+  lateinit var notifyProperties: NotifyProperties
 
   @MockitoSpyBean
   lateinit var prisonVisitBookedEventNotifierSpy: PrisonVisitBookedEventNotifier

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/ReplyToEmailResolverTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/ReplyToEmailResolverTest.kt
@@ -5,16 +5,16 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.config.NotifyProperties
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.prisoner.search.PrisonerSearchResultDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external.PrisonerSearchService
 
 class ReplyToEmailResolverTest {
   private val prisonerSearchService: PrisonerSearchService = mock()
-  private val notifyConfig = NotifyConfig().apply {
+  private val notifyProperties = NotifyProperties().apply {
     replyToEmailIds = mapOf("DEFAULT" to "00000000-0000-0000-0000-000000000001", "MDI" to "00000000-0000-0000-0000-000000000003")
   }
-  private val replyToEmailResolver = ReplyToEmailResolver(notifyConfig, prisonerSearchService)
+  private val replyToEmailResolver = ReplyToEmailResolver(notifyProperties, prisonerSearchService)
 
   @Test
   fun `uses configured reply-to email id for prisoner's current prison`() {
@@ -50,7 +50,7 @@ class ReplyToEmailResolverTest {
   @Test
   fun `throws when default reply-to email id is not configured`() {
     val replyToEmailResolver = ReplyToEmailResolver(
-      NotifyConfig().apply { replyToEmailIds = mapOf("MDI" to "00000000-0000-0000-0000-000000000003") },
+      NotifyProperties().apply { replyToEmailIds = mapOf("MDI" to "00000000-0000-0000-0000-000000000003") },
       prisonerSearchService,
     )
 


### PR DESCRIPTION
## What does this PR do?
- Rename 2 classes which were closely named to avoid confusion.
NotifyConfig -> NotifyProperties
NotifyConfigurations -> NotifyClientConfiguration

- Add a booker-registry-service to follow the theme of a service layer for all our external clients.