### PR TITLE
Visits - Multiple languages framework changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/visit/scheduler/ContactDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/dto/visit/scheduler/ContactDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Contact")
@@ -12,4 +13,6 @@ data class ContactDto(
   val telephone: String? = null,
   @param:Schema(description = "Contact Email", example = "example@email.com", required = false)
   val email: String? = null,
+  @param:Schema(description = "Contact language preference", example = "en", required = false)
+  val languagePreference: LanguagePreference = LanguagePreference.EN,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/email/BaseVisitsEmailNotificationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/email/BaseVisitsEmailNotificationHandler.kt
@@ -12,9 +12,6 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.Notification
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external.PrisonRegisterService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external.PrisonerContactRegistryService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external.PrisonerSearchService
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDate
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDayOfWeek
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedTime
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
@@ -43,38 +40,36 @@ abstract class BaseVisitsEmailNotificationHandler {
     languagePreference: LanguagePreference = LanguagePreference.EN,
   ): String = notificationTemplateResolver.getEmailTemplate(template = template, languagePreference = languagePreference)
 
-  protected fun getCommonTemplateVars(visit: VisitDto): MutableMap<String, Any> {
-    val templateVars: MutableMap<String, Any> = mutableMapOf(
-      "ref number" to visit.reference,
-      "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
-      "end time" to getFormattedTime(visit.endTimestamp.toLocalTime()),
-      "prison" to prisonRegisterService.getPrisonName(visit.prisonCode),
-      "dayofweek" to getFormattedDayOfWeek(visit.startTimestamp.toLocalDate()),
-      "date" to getFormattedDate(visit.startTimestamp.toLocalDate()),
-      "main contact name" to visit.visitContact.name,
+  protected fun getPrisoner(visit: VisitDto): Map<String, Any> {
+    val templateVars: MutableMap<String, Any> = prisonerSearchService.getPrisoner(visit.prisonerId)?.let { prisoner ->
+      mutableMapOf(
+        "opening sentence" to "visit to see $prisoner",
+        "prisoner" to "$prisoner",
+      )
+    } ?: mutableMapOf(
+      "opening sentence" to "visit to the prison",
+      "prisoner" to "the prisoner",
     )
-    templateVars.putAll(getPrisoner(visit))
-    templateVars.putAll(getPrisonContactDetails(visit))
+    when (visit.visitContact.languagePreference) {
+      LanguagePreference.CY -> templateVars.putAll(emptyMap<String, Any>())
+      else -> Unit
+    }
 
     return templateVars
   }
 
-  protected fun getPrisoner(visit: VisitDto): Map<String, Any> = prisonerSearchService.getPrisoner(visit.prisonerId)?.let { prisoner ->
-    mutableMapOf(
-      "opening sentence" to "visit to see $prisoner",
-      "prisoner" to "$prisoner",
-    )
-  } ?: mutableMapOf(
-    "opening sentence" to "visit to the prison",
-    "prisoner" to "the prisoner",
-  )
-
   protected fun getPrisonContactDetails(visit: VisitDto): Map<String, String> {
     val prisonContactDetails = prisonRegisterService.getPrisonSocialVisitsContactDetails(visit.prisonCode)
-    return mutableMapOf(
+    val templateVars = mutableMapOf(
       "phone" to (prisonContactDetails?.phoneNumber ?: GOV_UK_PRISON_PAGE),
       "website" to (prisonContactDetails?.webAddress ?: GOV_UK_PRISON_PAGE),
     )
+    when (visit.visitContact.languagePreference) {
+      LanguagePreference.CY -> templateVars.putAll(emptyMap<String, String>())
+      else -> Unit
+    }
+
+    return templateVars
   }
 
   protected fun getVisitors(visit: VisitDto): List<String> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/email/BookedEventVisitsEmailHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/email/BookedEventVisitsEmailHandler.kt
@@ -8,6 +8,8 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateN
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateNames.VISIT_REQUESTED
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.visit.scheduler.VisitRestriction
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDate
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDayOfWeek
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedTime
 
 @Service
@@ -20,27 +22,39 @@ class BookedEventVisitsEmailHandler : BaseVisitsEmailNotificationHandler() {
   override fun handle(visit: VisitDto): SendEmailNotificationDto {
     LOG.info("handleBookedEvent (email) - Entered, visit reference: {}, visit sub status: {}", visit.reference, visit.visitSubStatus)
 
-    val templateVars = getCommonTemplateVars(visit).toMutableMap()
-
-    templateVars.putAll(
-      mapOf(
-        "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
-        "end time" to getFormattedTime(visit.endTimestamp.toLocalTime()),
-        "arrival time" to "45",
-        "closed visit" to (visit.visitRestriction == VisitRestriction.CLOSED).toString(),
-        "visitors" to getVisitors(visit),
-      ),
-    )
-
     return SendEmailNotificationDto(
       templateName = getTemplateName(visit),
-      templateVars = templateVars,
+      templateVars = getTemplateVars(visit),
     )
   }
 
+  private fun getTemplateVars(visit: VisitDto): Map<String, Any> {
+    val templateVars: MutableMap<String, Any> = mutableMapOf(
+      "ref number" to visit.reference,
+      "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
+      "end time" to getFormattedTime(visit.endTimestamp.toLocalTime()),
+      "arrival time" to "45",
+      "prison" to prisonRegisterService.getPrisonName(visit.prisonCode),
+      "dayofweek" to getFormattedDayOfWeek(visit.startTimestamp.toLocalDate()),
+      "date" to getFormattedDate(visit.startTimestamp.toLocalDate()),
+      "main contact name" to visit.visitContact.name,
+      "closed visit" to (visit.visitRestriction == VisitRestriction.CLOSED).toString(),
+      "visitors" to getVisitors(visit),
+    )
+    templateVars.putAll(getPrisoner(visit))
+    templateVars.putAll(getPrisonContactDetails(visit))
+
+    when (visit.visitContact.languagePreference) {
+      LanguagePreference.CY -> templateVars.putAll(emptyMap<String, Any>())
+      else -> Unit
+    }
+
+    return templateVars
+  }
+
   private fun getTemplateName(visit: VisitDto): String = if (visit.visitSubStatus == "REQUESTED") {
-    getTemplateName(VISIT_REQUESTED, languagePreference = LanguagePreference.EN)
+    getTemplateName(VISIT_REQUESTED, languagePreference = visit.visitContact.languagePreference)
   } else {
-    getTemplateName(VISIT_BOOKING_OR_REQUEST_APPROVED, languagePreference = LanguagePreference.EN)
+    getTemplateName(VISIT_BOOKING_OR_REQUEST_APPROVED, languagePreference = visit.visitContact.languagePreference)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/email/CancelledEventVisitsEmailHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/email/CancelledEventVisitsEmailHandler.kt
@@ -7,6 +7,9 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.SendEmailNotific
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateNames
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDate
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDayOfWeek
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedTime
 
 @Service
 class CancelledEventVisitsEmailHandler : BaseVisitsEmailNotificationHandler() {
@@ -19,8 +22,28 @@ class CancelledEventVisitsEmailHandler : BaseVisitsEmailNotificationHandler() {
 
     return SendEmailNotificationDto(
       templateName = getCancelledEmailTemplateName(visit),
-      templateVars = getCommonTemplateVars(visit),
+      templateVars = getTemplateVars(visit),
     )
+  }
+
+  private fun getTemplateVars(visit: VisitDto): Map<String, Any> {
+    val templateVars: MutableMap<String, Any> = mutableMapOf(
+      "ref number" to visit.reference,
+      "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
+      "end time" to getFormattedTime(visit.endTimestamp.toLocalTime()),
+      "prison" to prisonRegisterService.getPrisonName(visit.prisonCode),
+      "dayofweek" to getFormattedDayOfWeek(visit.startTimestamp.toLocalDate()),
+      "date" to getFormattedDate(visit.startTimestamp.toLocalDate()),
+      "main contact name" to visit.visitContact.name,
+    )
+    templateVars.putAll(getPrisoner(visit))
+    templateVars.putAll(getPrisonContactDetails(visit))
+    when (visit.visitContact.languagePreference) {
+      LanguagePreference.CY -> templateVars.putAll(emptyMap<String, Any>())
+      else -> Unit
+    }
+
+    return templateVars
   }
 
   private fun getCancelledEmailTemplateName(visit: VisitDto): String {
@@ -48,6 +71,6 @@ class CancelledEventVisitsEmailHandler : BaseVisitsEmailNotificationHandler() {
       }
     }
 
-    return getTemplateName(template, languagePreference = LanguagePreference.EN)
+    return getTemplateName(template, languagePreference = visit.visitContact.languagePreference)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/email/RequestApprovedEventVisitsEmailHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/email/RequestApprovedEventVisitsEmailHandler.kt
@@ -8,6 +8,8 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateNames.VISIT_BOOKING_OR_REQUEST_APPROVED
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.visit.scheduler.VisitRestriction
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDate
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDayOfWeek
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedTime
 
 @Service
@@ -20,33 +22,44 @@ class RequestApprovedEventVisitsEmailHandler : BaseVisitsEmailNotificationHandle
   override fun handle(visit: VisitDto): SendEmailNotificationDto {
     LOG.info("handleRequestApproved (email) - Entered")
 
-    val templateVars = getCommonTemplateVars(visit).toMutableMap()
-
-    templateVars.putAll(
-      mapOf(
-        "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
-        "end time" to getFormattedTime(visit.endTimestamp.toLocalTime()),
-        "arrival time" to "45",
-        "closed visit" to (visit.visitRestriction == VisitRestriction.CLOSED).toString(),
-        "visitors" to getVisitors(visit),
-      ),
-    )
-
-    return SendEmailNotificationDto(templateName = getRequestApprovedEmailTemplateName(visit.visitSubStatus), templateVars = templateVars)
+    return SendEmailNotificationDto(templateName = getRequestApprovedEmailTemplateName(visit), templateVars = getTemplateVars(visit))
   }
 
-  private fun getRequestApprovedEmailTemplateName(visitSubStatus: String): String {
-    val template = when (visitSubStatus) {
+  private fun getTemplateVars(visit: VisitDto): Map<String, Any> {
+    val templateVars: MutableMap<String, Any> = mutableMapOf(
+      "ref number" to visit.reference,
+      "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
+      "end time" to getFormattedTime(visit.endTimestamp.toLocalTime()),
+      "arrival time" to "45",
+      "prison" to prisonRegisterService.getPrisonName(visit.prisonCode),
+      "dayofweek" to getFormattedDayOfWeek(visit.startTimestamp.toLocalDate()),
+      "date" to getFormattedDate(visit.startTimestamp.toLocalDate()),
+      "main contact name" to visit.visitContact.name,
+      "closed visit" to (visit.visitRestriction == VisitRestriction.CLOSED).toString(),
+      "visitors" to getVisitors(visit),
+    )
+    templateVars.putAll(getPrisoner(visit))
+    templateVars.putAll(getPrisonContactDetails(visit))
+    when (visit.visitContact.languagePreference) {
+      LanguagePreference.CY -> templateVars.putAll(emptyMap<String, Any>())
+      else -> Unit
+    }
+
+    return templateVars
+  }
+
+  private fun getRequestApprovedEmailTemplateName(visit: VisitDto): String {
+    val template = when (visit.visitSubStatus) {
       "APPROVED", "AUTO_APPROVED" -> {
         VISIT_BOOKING_OR_REQUEST_APPROVED
       }
 
       else -> {
-        LOG.error("visit request approved for visit sub status $visitSubStatus is unsupported")
-        throw ValidationException("visit request approved for visit sub status $visitSubStatus is unsupported")
+        LOG.error("visit request approved for visit sub status ${visit.visitSubStatus} is unsupported")
+        throw ValidationException("visit request approved for visit sub status ${visit.visitSubStatus} is unsupported")
       }
     }
 
-    return getTemplateName(template, languagePreference = LanguagePreference.EN)
+    return getTemplateName(template, languagePreference = visit.visitContact.languagePreference)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/email/UpdatedEventVisitsEmailHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/email/UpdatedEventVisitsEmailHandler.kt
@@ -7,6 +7,8 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateNames
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.visit.scheduler.VisitRestriction
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDate
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDayOfWeek
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedTime
 
 @Service
@@ -19,21 +21,32 @@ class UpdatedEventVisitsEmailHandler : BaseVisitsEmailNotificationHandler() {
   override fun handle(visit: VisitDto): SendEmailNotificationDto {
     LOG.info("handleUpdatedEvent (email) - Entered")
 
-    val templateVars = getCommonTemplateVars(visit).toMutableMap()
-
-    templateVars.putAll(
-      mapOf(
-        "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
-        "end time" to getFormattedTime(visit.endTimestamp.toLocalTime()),
-        "arrival time" to "45",
-        "closed visit" to (visit.visitRestriction == VisitRestriction.CLOSED).toString(),
-        "visitors" to getVisitors(visit),
-      ),
-    )
-
     return SendEmailNotificationDto(
-      templateName = getTemplateName(EmailTemplateNames.VISIT_UPDATED, languagePreference = LanguagePreference.EN),
-      templateVars = templateVars,
+      templateName = getTemplateName(EmailTemplateNames.VISIT_UPDATED, languagePreference = visit.visitContact.languagePreference),
+      templateVars = getTemplateVars(visit),
     )
+  }
+
+  private fun getTemplateVars(visit: VisitDto): Map<String, Any> {
+    val templateVars: MutableMap<String, Any> = mutableMapOf(
+      "ref number" to visit.reference,
+      "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
+      "end time" to getFormattedTime(visit.endTimestamp.toLocalTime()),
+      "arrival time" to "45",
+      "prison" to prisonRegisterService.getPrisonName(visit.prisonCode),
+      "dayofweek" to getFormattedDayOfWeek(visit.startTimestamp.toLocalDate()),
+      "date" to getFormattedDate(visit.startTimestamp.toLocalDate()),
+      "main contact name" to visit.visitContact.name,
+      "closed visit" to (visit.visitRestriction == VisitRestriction.CLOSED).toString(),
+      "visitors" to getVisitors(visit),
+    )
+    templateVars.putAll(getPrisoner(visit))
+    templateVars.putAll(getPrisonContactDetails(visit))
+    when (visit.visitContact.languagePreference) {
+      LanguagePreference.CY -> templateVars.putAll(emptyMap<String, Any>())
+      else -> Unit
+    }
+
+    return templateVars
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/sms/BaseVisitsSmsNotificationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/sms/BaseVisitsSmsNotificationHandler.kt
@@ -8,9 +8,6 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePrefer
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNames
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.NotificationTemplateResolver
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external.PrisonRegisterService
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDate
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDayOfWeek
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedTime
 
 @Service
 abstract class BaseVisitsSmsNotificationHandler {
@@ -27,16 +24,4 @@ abstract class BaseVisitsSmsNotificationHandler {
     template: SmsTemplateNames,
     languagePreference: LanguagePreference = LanguagePreference.EN,
   ): String = notificationTemplateResolver.getSmsTemplate(template = template, languagePreference = languagePreference)
-
-  protected fun getCommonTemplateVars(visit: VisitDto): MutableMap<String, String> {
-    val templateVars = mutableMapOf(
-      "ref number" to visit.reference,
-      "prison" to prisonRegisterService.getPrisonName(visit.prisonCode),
-      "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
-      "dayofweek" to getFormattedDayOfWeek(visit.startTimestamp.toLocalDate()),
-      "date" to getFormattedDate(visit.startTimestamp.toLocalDate()),
-    )
-
-    return templateVars
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/sms/BookedEventVisitsSmsHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/sms/BookedEventVisitsSmsHandler.kt
@@ -4,8 +4,12 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.SendSmsNotificationDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNames.VISIT_BOOKING_OR_REQUEST_APPROVED
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNames.VISIT_REQUESTED
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDate
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDayOfWeek
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedTime
 
 @Service
 class BookedEventVisitsSmsHandler : BaseVisitsSmsNotificationHandler() {
@@ -17,18 +21,31 @@ class BookedEventVisitsSmsHandler : BaseVisitsSmsNotificationHandler() {
   override fun handle(visit: VisitDto): SendSmsNotificationDto {
     LOG.info("handleBookedEvent (sms) - Entered, visit reference: {}, visit sub status: {}", visit.reference, visit.visitSubStatus)
 
-    val templateVars = getCommonTemplateVars(visit)
-    templateVars["ref number"] = visit.reference
-
     return SendSmsNotificationDto(
       templateName = getTemplateName(visit),
-      templateVars = templateVars,
+      templateVars = getTemplateVars(visit),
     )
   }
 
+  private fun getTemplateVars(visit: VisitDto): Map<String, String> {
+    val templateVars = mutableMapOf(
+      "ref number" to visit.reference,
+      "prison" to prisonRegisterService.getPrisonName(visit.prisonCode),
+      "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
+      "dayofweek" to getFormattedDayOfWeek(visit.startTimestamp.toLocalDate()),
+      "date" to getFormattedDate(visit.startTimestamp.toLocalDate()),
+    )
+    when (visit.visitContact.languagePreference) {
+      LanguagePreference.CY -> templateVars.putAll(emptyMap<String, String>())
+      else -> Unit
+    }
+
+    return templateVars
+  }
+
   private fun getTemplateName(visit: VisitDto): String = if (visit.visitSubStatus == "REQUESTED") {
-    getTemplateName(VISIT_REQUESTED)
+    getTemplateName(VISIT_REQUESTED, languagePreference = visit.visitContact.languagePreference)
   } else {
-    getTemplateName(VISIT_BOOKING_OR_REQUEST_APPROVED)
+    getTemplateName(VISIT_BOOKING_OR_REQUEST_APPROVED, languagePreference = visit.visitContact.languagePreference)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/sms/CancelledEventVisitsSmsHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/sms/CancelledEventVisitsSmsHandler.kt
@@ -4,9 +4,13 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.SendSmsNotificationDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNames.VISIT_CANCEL
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNames.VISIT_CANCEL_NO_PRISON_NUMBER
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNames.VISIT_REQUEST_REJECTED
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDate
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDayOfWeek
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedTime
 
 @Service
 class CancelledEventVisitsSmsHandler : BaseVisitsSmsNotificationHandler() {
@@ -18,20 +22,35 @@ class CancelledEventVisitsSmsHandler : BaseVisitsSmsNotificationHandler() {
   override fun handle(visit: VisitDto): SendSmsNotificationDto {
     LOG.info("handleCancelledEvent (sms) - Entered for visit reference - ${visit.reference} with sub status - ${visit.visitSubStatus}")
 
-    val templateVars = getCommonTemplateVars(visit)
-    templateVars["reference"] = visit.reference
-
     val prisonContactNumber: String? = prisonRegisterService.getPrisonSocialVisitsContactDetails(visit.prisonCode)?.phoneNumber
     val isPrisonContactNumberAvailable = !prisonContactNumber.isNullOrEmpty()
-    if (isPrisonContactNumberAvailable) {
-      templateVars["prison phone number"] = prisonContactNumber
-    }
-    val templateName = getCancelledSmsTemplateName(visit.visitSubStatus, isPrisonContactNumberAvailable)
+    val templateVars = getTemplateVars(visit, prisonContactNumber)
+    val templateName = getCancelledSmsTemplateName(visit, isPrisonContactNumberAvailable)
     return SendSmsNotificationDto(templateName, templateVars)
   }
 
-  private fun getCancelledSmsTemplateName(visitSubStatus: String, isPrisonContactNumberAvailable: Boolean): String {
-    val template = when (visitSubStatus) {
+  private fun getTemplateVars(visit: VisitDto, prisonContactNumber: String?): Map<String, String> {
+    val templateVars = mutableMapOf(
+      "ref number" to visit.reference,
+      "prison" to prisonRegisterService.getPrisonName(visit.prisonCode),
+      "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
+      "dayofweek" to getFormattedDayOfWeek(visit.startTimestamp.toLocalDate()),
+      "date" to getFormattedDate(visit.startTimestamp.toLocalDate()),
+      "reference" to visit.reference,
+    )
+    if (!prisonContactNumber.isNullOrEmpty()) {
+      templateVars["prison phone number"] = prisonContactNumber
+    }
+    when (visit.visitContact.languagePreference) {
+      LanguagePreference.CY -> templateVars.putAll(emptyMap<String, String>())
+      else -> Unit
+    }
+
+    return templateVars
+  }
+
+  private fun getCancelledSmsTemplateName(visit: VisitDto, isPrisonContactNumberAvailable: Boolean): String {
+    val template = when (visit.visitSubStatus) {
       "REJECTED", "AUTO_REJECTED" -> {
         VISIT_REQUEST_REJECTED
       }
@@ -43,6 +62,6 @@ class CancelledEventVisitsSmsHandler : BaseVisitsSmsNotificationHandler() {
       }
     }
 
-    return getTemplateName(template)
+    return getTemplateName(template, languagePreference = visit.visitContact.languagePreference)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/sms/RequestApprovedEventVisitsSmsHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/sms/RequestApprovedEventVisitsSmsHandler.kt
@@ -5,7 +5,11 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.SendSmsNotificationDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNames.VISIT_BOOKING_OR_REQUEST_APPROVED
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDate
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDayOfWeek
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedTime
 
 @Service
 class RequestApprovedEventVisitsSmsHandler : BaseVisitsSmsNotificationHandler() {
@@ -17,24 +21,37 @@ class RequestApprovedEventVisitsSmsHandler : BaseVisitsSmsNotificationHandler() 
   override fun handle(visit: VisitDto): SendSmsNotificationDto {
     LOG.info("handleRequestApproved (sms) - Entered")
 
-    val templateVars = getCommonTemplateVars(visit)
-    templateVars["ref number"] = visit.reference
-
-    return SendSmsNotificationDto(templateName = getRequestApprovedSmsTemplateName(visit.visitSubStatus), templateVars = templateVars)
+    return SendSmsNotificationDto(templateName = getRequestApprovedSmsTemplateName(visit), templateVars = getTemplateVars(visit))
   }
 
-  private fun getRequestApprovedSmsTemplateName(visitSubStatus: String): String {
-    val template = when (visitSubStatus) {
+  private fun getTemplateVars(visit: VisitDto): Map<String, String> {
+    val templateVars = mutableMapOf(
+      "ref number" to visit.reference,
+      "prison" to prisonRegisterService.getPrisonName(visit.prisonCode),
+      "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
+      "dayofweek" to getFormattedDayOfWeek(visit.startTimestamp.toLocalDate()),
+      "date" to getFormattedDate(visit.startTimestamp.toLocalDate()),
+    )
+    when (visit.visitContact.languagePreference) {
+      LanguagePreference.CY -> templateVars.putAll(emptyMap<String, String>())
+      else -> Unit
+    }
+
+    return templateVars
+  }
+
+  private fun getRequestApprovedSmsTemplateName(visit: VisitDto): String {
+    val template = when (visit.visitSubStatus) {
       "APPROVED", "AUTO_APPROVED" -> {
         VISIT_BOOKING_OR_REQUEST_APPROVED
       }
 
       else -> {
-        LOG.error("visit request approved for visit sub status $visitSubStatus is unsupported")
-        throw ValidationException("visit request approved for visit sub status $visitSubStatus is unsupported")
+        LOG.error("visit request approved for visit sub status ${visit.visitSubStatus} is unsupported")
+        throw ValidationException("visit request approved for visit sub status ${visit.visitSubStatus} is unsupported")
       }
     }
 
-    return getTemplateName(template)
+    return getTemplateName(template, languagePreference = visit.visitContact.languagePreference)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/sms/UpdatedEventVisitsSmsHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/handlers/sms/UpdatedEventVisitsSmsHandler.kt
@@ -4,7 +4,11 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.SendSmsNotificationDto
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.visit.scheduler.VisitDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.SmsTemplateNames
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDate
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedDayOfWeek
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.utils.DateUtils.Companion.getFormattedTime
 
 @Service
 class UpdatedEventVisitsSmsHandler : BaseVisitsSmsNotificationHandler() {
@@ -16,9 +20,22 @@ class UpdatedEventVisitsSmsHandler : BaseVisitsSmsNotificationHandler() {
   override fun handle(visit: VisitDto): SendSmsNotificationDto {
     LOG.info("handleUpdatedEvent (sms) - Entered")
 
-    val templateVars = getCommonTemplateVars(visit)
-    templateVars["ref number"] = visit.reference
+    return SendSmsNotificationDto(templateName = getTemplateName(SmsTemplateNames.VISIT_UPDATE, languagePreference = visit.visitContact.languagePreference), templateVars = getTemplateVars(visit))
+  }
 
-    return SendSmsNotificationDto(templateName = getTemplateName(SmsTemplateNames.VISIT_UPDATE), templateVars = templateVars)
+  private fun getTemplateVars(visit: VisitDto): Map<String, String> {
+    val templateVars = mutableMapOf(
+      "ref number" to visit.reference,
+      "prison" to prisonRegisterService.getPrisonName(visit.prisonCode),
+      "time" to getFormattedTime(visit.startTimestamp.toLocalTime()),
+      "dayofweek" to getFormattedDayOfWeek(visit.startTimestamp.toLocalDate()),
+      "date" to getFormattedDate(visit.startTimestamp.toLocalDate()),
+    )
+    when (visit.visitContact.languagePreference) {
+      LanguagePreference.CY -> templateVars.putAll(emptyMap<String, String>())
+      else -> Unit
+    }
+
+    return templateVars
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitBookedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitBookedEventEmailTest.kt
@@ -576,8 +576,9 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
   @Test
   fun `when visit booked message is received and language is welsh but no welsh template exists, then booking message is sent in english`() {
     // Given
-    val bookingReference = visit.reference
-    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val welshVisit = visit.copy(visitContact = visit.visitContact.copy(languagePreference = LanguagePreference.CY))
+    val bookingReference = welshVisit.reference
+    val visitAdditionalInfo = VisitAdditionalInfo(welshVisit.reference, "123456")
 
     val visitor1 = ContactWithOptionalPrisonerRelationshipDto(1234, "Visitor", "One", (LocalDate.now().minusYears(30)))
     val visitor2 = ContactWithOptionalPrisonerRelationshipDto(9876, "Visitor", "Two")
@@ -586,7 +587,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = notificationTemplateResolver.getEmailTemplate(EmailTemplateNames.VISIT_BOOKING_OR_REQUEST_APPROVED, LanguagePreference.CY)
-    val visitDate = visit.startTimestamp.toLocalDate()
+    val visitDate = welshVisit.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
     val expectedDayOfWeek = visitDate.dayOfWeek.toString().lowercase().replaceFirstChar { it.titlecase() }
     val templateVars = mutableMapOf<String, Any>(
@@ -610,15 +611,15 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
-    visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
+    visitSchedulerMockServer.stubGetVisit(bookingReference, welshVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
-    prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
+    prisonerOffenderSearchMockServer.stubGetPrisoner(welshVisit.prisonerId, prisonerSearchResult)
+    prisonerContactRegisterMockServer.stubSearchContacts(welshVisit.prisonerId, welshVisit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
         templateId,
-        visit.visitContact.email,
+        welshVisit.visitContact.email,
         templateVars,
         visitAdditionalInfo.eventAuditId,
         "00000000-0000-0000-0000-000000000002",
@@ -627,7 +628,7 @@ class PrisonVisitBookedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
-    verifyEmailSent(templateId, visit, visitAdditionalInfo, templateVars)
+    verifyEmailSent(templateId, welshVisit, visitAdditionalInfo, templateVars)
   }
 
   private fun verifyEmailSent(templateId: String, visit: VisitDto, visitAdditionalInfo: VisitAdditionalInfo, templateVars: Map<String, Any>) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitCancelledEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitCancelledEventEmailTest.kt
@@ -459,24 +459,25 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
   @Test
   fun `when visit cancelled message is received with welsh language but no welsh template exists then cancelled email is sent in english`() {
     // Given
-    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val welshVisit = visit.copy(visitContact = visit.visitContact.copy(languagePreference = LanguagePreference.CY))
+    val visitAdditionalInfo = VisitAdditionalInfo(welshVisit.reference, "123456")
     val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = notificationTemplateResolver.getEmailTemplate(EmailTemplateNames.VISIT_CANCELLED, LanguagePreference.CY)
-    val templateVars = createTemplateVars(visit)
+    val templateVars = createTemplateVars(welshVisit)
     val notificationClientResponse = buildSendEmailResponse(reference = visitAdditionalInfo.eventAuditId)
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
-    visitSchedulerMockServer.stubGetVisit(visit.reference, visit)
+    visitSchedulerMockServer.stubGetVisit(welshVisit.reference, welshVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
-    prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, prisonerSearchResult)
+    prisonerOffenderSearchMockServer.stubGetPrisoner(welshVisit.prisonerId, prisonerSearchResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
         templateId,
-        visit.visitContact.email,
+        welshVisit.visitContact.email,
         templateVars,
         visitAdditionalInfo.eventAuditId,
         "00000000-0000-0000-0000-000000000002",
@@ -485,7 +486,7 @@ class PrisonVisitCancelledEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
-    verifyEmailSent(templateId, visit, visitAdditionalInfo, templateVars)
+    verifyEmailSent(templateId, welshVisit, visitAdditionalInfo, templateVars)
   }
 
   private fun createTemplateVars(visit: VisitDto, openingSentence: String? = "visit to see $prisonerSearchResult", prisoner: String? = prisonerSearchResult.toString(), phone: String? = prisonContactDetailsDto.phoneNumber, webAddress: String? = prisonContactDetailsDto.webAddress): Map<String, Any> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitRequestApprovedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitRequestApprovedEventEmailTest.kt
@@ -256,8 +256,9 @@ class PrisonVisitRequestApprovedEventEmailTest : EventsIntegrationTestBase() {
   @Test
   fun `when visit request approved event received in welsh and visit was approved but no welsh template exists then visit booked email is sent in english`() {
     // Given
-    val bookingReference = approvedVisit.reference
-    val visitAdditionalInfo = VisitAdditionalInfo(approvedVisit.reference, "123456")
+    val welshApprovedVisit = approvedVisit.copy(visitContact = approvedVisit.visitContact.copy(languagePreference = LanguagePreference.CY))
+    val bookingReference = welshApprovedVisit.reference
+    val visitAdditionalInfo = VisitAdditionalInfo(welshApprovedVisit.reference, "123456")
     val visitor1 = ContactWithOptionalPrisonerRelationshipDto(1234, "Visitor", "One", (LocalDate.now().minusYears(30)))
     val visitor2 = ContactWithOptionalPrisonerRelationshipDto(9876, "Visitor", "Two")
 
@@ -265,7 +266,7 @@ class PrisonVisitRequestApprovedEventEmailTest : EventsIntegrationTestBase() {
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = notificationTemplateResolver.getEmailTemplate(EmailTemplateNames.VISIT_BOOKING_OR_REQUEST_APPROVED, LanguagePreference.CY)
-    val visitDate = approvedVisit.startTimestamp.toLocalDate()
+    val visitDate = welshApprovedVisit.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
     val expectedDayOfWeek = visitDate.dayOfWeek.toString().lowercase().replaceFirstChar { it.titlecase() }
     val templateVars = mutableMapOf<String, Any>(
@@ -289,15 +290,15 @@ class PrisonVisitRequestApprovedEventEmailTest : EventsIntegrationTestBase() {
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
-    visitSchedulerMockServer.stubGetVisit(bookingReference, approvedVisit)
+    visitSchedulerMockServer.stubGetVisit(bookingReference, welshApprovedVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
-    prisonerOffenderSearchMockServer.stubGetPrisoner(approvedVisit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchContacts(approvedVisit.prisonerId, approvedVisit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
+    prisonerOffenderSearchMockServer.stubGetPrisoner(welshApprovedVisit.prisonerId, prisonerSearchResult)
+    prisonerContactRegisterMockServer.stubSearchContacts(welshApprovedVisit.prisonerId, welshApprovedVisit.visitors.map { it.nomisPersonId }, false, listOf(visitor1, visitor2))
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
         templateId,
-        approvedVisit.visitContact.email,
+        welshApprovedVisit.visitContact.email,
         templateVars,
         visitAdditionalInfo.eventAuditId,
         "00000000-0000-0000-0000-000000000002",
@@ -306,7 +307,7 @@ class PrisonVisitRequestApprovedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
-    verifyEmailSent(templateId, approvedVisit, visitAdditionalInfo, templateVars)
+    verifyEmailSent(templateId, welshApprovedVisit, visitAdditionalInfo, templateVars)
   }
 
   private fun verifyEmailSent(templateId: String, visit: VisitDto, visitAdditionalInfo: VisitAdditionalInfo, templateVars: Map<String, Any>) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitRequestedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitRequestedEventEmailTest.kt
@@ -191,14 +191,15 @@ class PrisonVisitRequestedEventEmailTest : EventsIntegrationTestBase() {
   @Test
   fun `when visit requested message is received and language is welsh but no welsh template exists, then visit request is sent in english`() {
     // Given
-    val bookingReference = visit.reference
-    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val welshVisit = visit.copy(visitContact = visit.visitContact.copy(languagePreference = LanguagePreference.CY))
+    val bookingReference = welshVisit.reference
+    val visitAdditionalInfo = VisitAdditionalInfo(welshVisit.reference, "123456")
 
     val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = notificationTemplateResolver.getEmailTemplate(VISIT_REQUESTED, LanguagePreference.CY)
-    val visitDate = visit.startTimestamp.toLocalDate()
+    val visitDate = welshVisit.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
     val expectedDayOfWeek = visitDate.dayOfWeek.toString().lowercase().replaceFirstChar { it.titlecase() }
     val templateVars = mutableMapOf<String, Any>(
@@ -222,15 +223,15 @@ class PrisonVisitRequestedEventEmailTest : EventsIntegrationTestBase() {
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
-    visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
+    visitSchedulerMockServer.stubGetVisit(bookingReference, welshVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
-    prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
+    prisonerOffenderSearchMockServer.stubGetPrisoner(welshVisit.prisonerId, prisonerSearchResult)
+    prisonerContactRegisterMockServer.stubSearchContacts(welshVisit.prisonerId, welshVisit.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
         templateId,
-        visit.visitContact.email,
+        welshVisit.visitContact.email,
         templateVars,
         visitAdditionalInfo.eventAuditId,
         "00000000-0000-0000-0000-000000000002",
@@ -239,7 +240,7 @@ class PrisonVisitRequestedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
-    verifyEmailSent(templateId, visit, visitAdditionalInfo, templateVars)
+    verifyEmailSent(templateId, welshVisit, visitAdditionalInfo, templateVars)
   }
 
   private fun verifyEmailSent(templateId: String, visit: VisitDto, visitAdditionalInfo: VisitAdditionalInfo, templateVars: Map<String, Any>) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitUpdatedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/PrisonVisitUpdatedEventEmailTest.kt
@@ -565,14 +565,15 @@ class PrisonVisitUpdatedEventEmailTest : EventsIntegrationTestBase() {
   @Test
   fun `when visit updated message is received and language is welsh but no welsh template exists, then update message is sent in english`() {
     // Given
-    val bookingReference = visit.reference
-    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val welshVisit = visit.copy(visitContact = visit.visitContact.copy(languagePreference = LanguagePreference.CY))
+    val bookingReference = welshVisit.reference
+    val visitAdditionalInfo = VisitAdditionalInfo(welshVisit.reference, "123456")
 
     val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = notificationTemplateResolver.getEmailTemplate(EmailTemplateNames.VISIT_UPDATED, LanguagePreference.CY)
-    val visitDate = visit.startTimestamp.toLocalDate()
+    val visitDate = welshVisit.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
     val expectedDayOfWeek = visitDate.dayOfWeek.toString().lowercase().replaceFirstChar { it.titlecase() }
     val templateVars = mutableMapOf<String, Any>(
@@ -594,15 +595,15 @@ class PrisonVisitUpdatedEventEmailTest : EventsIntegrationTestBase() {
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
-    visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
+    visitSchedulerMockServer.stubGetVisit(bookingReference, welshVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
-    prisonerOffenderSearchMockServer.stubGetPrisoner(visit.prisonerId, prisonerSearchResult)
-    prisonerContactRegisterMockServer.stubSearchContacts(visit.prisonerId, visit.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
+    prisonerOffenderSearchMockServer.stubGetPrisoner(welshVisit.prisonerId, prisonerSearchResult)
+    prisonerContactRegisterMockServer.stubSearchContacts(welshVisit.prisonerId, welshVisit.visitors.map { it.nomisPersonId }, false, prisonerContactsResult)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendEmail(
         templateId,
-        visit.visitContact.email,
+        welshVisit.visitContact.email,
         templateVars,
         visitAdditionalInfo.eventAuditId,
         "00000000-0000-0000-0000-000000000002",
@@ -611,7 +612,7 @@ class PrisonVisitUpdatedEventEmailTest : EventsIntegrationTestBase() {
     visitSchedulerMockServer.stubCreateNotifyNotification(HttpStatus.OK)
 
     // Then
-    verifyEmailSent(templateId, visit, visitAdditionalInfo, templateVars)
+    verifyEmailSent(templateId, welshVisit, visitAdditionalInfo, templateVars)
   }
 
   private fun verifyEmailSent(templateId: String, visit: VisitDto, visitAdditionalInfo: VisitAdditionalInfo, templateVars: Map<String, Any>) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitBookedEventSmsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitBookedEventSmsTest.kt
@@ -347,13 +347,14 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
   @Test
   fun `when visit booked message is received and language is welsh but no welsh template exists, then booking message is sent in english`() {
     // Given
-    val bookingReference = visit.reference
-    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val welshVisit = visit.copy(visitContact = visit.visitContact.copy(languagePreference = LanguagePreference.CY))
+    val bookingReference = welshVisit.reference
+    val visitAdditionalInfo = VisitAdditionalInfo(welshVisit.reference, "123456")
     val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = notificationTemplateResolver.getSmsTemplate(SmsTemplateNames.VISIT_BOOKING_OR_REQUEST_APPROVED, LanguagePreference.CY)
-    val visitDate = visit.startTimestamp.toLocalDate()
+    val visitDate = welshVisit.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
     val expectedDayOfWeek = visitDate.dayOfWeek.toString().lowercase().replaceFirstChar { it.titlecase() }
     val templateVars = mutableMapOf<String, Any>(
@@ -366,17 +367,17 @@ class PrisonVisitBookedEventSmsTest : EventsIntegrationTestBase() {
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
-    visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
+    visitSchedulerMockServer.stubGetVisit(bookingReference, welshVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(welshVisit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
-        visit.visitContact.telephone,
+        welshVisit.visitContact.telephone,
         templateVars,
         visitAdditionalInfo.eventAuditId,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitCancelledEventSmsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitCancelledEventSmsTest.kt
@@ -652,11 +652,12 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
   @Test
   fun `when visit cancelled message is received and language is welsh but no welsh template exists, then cancelled message is sent in english`() {
     // Given
-    val bookingReference = visit.reference
-    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val welshVisit = visit.copy(visitContact = visit.visitContact.copy(languagePreference = LanguagePreference.CY))
+    val bookingReference = welshVisit.reference
+    val visitAdditionalInfo = VisitAdditionalInfo(welshVisit.reference, "123456")
     val domainEvent = createDomainEventJson(PRISON_VISIT_CANCELLED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
-    val visitDate = visit.startTimestamp.toLocalDate()
+    val visitDate = welshVisit.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
     val expectedDayOfWeek = visitDate.dayOfWeek.toString().lowercase().replaceFirstChar { it.titlecase() }
     val templateId = notificationTemplateResolver.getSmsTemplate(SmsTemplateNames.VISIT_CANCEL, LanguagePreference.CY)
@@ -673,13 +674,13 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
-    visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
+    visitSchedulerMockServer.stubGetVisit(bookingReference, welshVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
     prisonRegisterMockServer.stubGetPrisonSocialVisitContactDetails(prison.prisonId, prisonContactDetailsDto)
     Mockito.`when`(
       notificationClient.sendSms(
         templateId,
-        visit.visitContact.telephone,
+        welshVisit.visitContact.telephone,
         templateVars,
         visitAdditionalInfo.eventAuditId,
       ),
@@ -689,11 +690,11 @@ class PrisonVisitCancelledEventSmsTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(prisonVisitCancelledEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.CANCELLED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(welshVisit, VisitEventType.CANCELLED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
-        visit.visitContact.telephone,
+        welshVisit.visitContact.telephone,
         templateVars,
         visitAdditionalInfo.eventAuditId,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitRequestedEventSmsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitRequestedEventSmsTest.kt
@@ -167,13 +167,14 @@ class PrisonVisitRequestedEventSmsTest : EventsIntegrationTestBase() {
   @Test
   fun `when visit requested message is received and language is welsh but no welsh template exists, then request message is sent in english`() {
     // Given
-    val bookingReference = visit.reference
-    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val welshVisit = visit.copy(visitContact = visit.visitContact.copy(languagePreference = LanguagePreference.CY))
+    val bookingReference = welshVisit.reference
+    val visitAdditionalInfo = VisitAdditionalInfo(welshVisit.reference, "123456")
     val domainEvent = createDomainEventJson(PRISON_VISIT_BOOKED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
     val templateId = notificationTemplateResolver.getSmsTemplate(SmsTemplateNames.VISIT_REQUESTED, LanguagePreference.CY)
-    val visitDate = visit.startTimestamp.toLocalDate()
+    val visitDate = welshVisit.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
     val expectedDayOfWeek = visitDate.dayOfWeek.toString().lowercase().replaceFirstChar { it.titlecase() }
     val templateVars = mutableMapOf<String, Any>(
@@ -186,17 +187,17 @@ class PrisonVisitRequestedEventSmsTest : EventsIntegrationTestBase() {
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
-    visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
+    visitSchedulerMockServer.stubGetVisit(bookingReference, welshVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
 
     // Then
     await untilAsserted { verify(prisonVisitBookedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.BOOKED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(welshVisit, VisitEventType.BOOKED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
-        visit.visitContact.telephone,
+        welshVisit.visitContact.telephone,
         templateVars,
         visitAdditionalInfo.eventAuditId,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitUpdateEventSmsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/sms/PrisonVisitUpdateEventSmsTest.kt
@@ -350,11 +350,12 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
   @Test
   fun `when visit updated message is received and language is welsh but no welsh template exists, then update message is sent in english`() {
     // Given
-    val bookingReference = visit.reference
-    val visitAdditionalInfo = VisitAdditionalInfo(visit.reference, "123456")
+    val welshVisit = visit.copy(visitContact = visit.visitContact.copy(languagePreference = LanguagePreference.CY))
+    val bookingReference = welshVisit.reference
+    val visitAdditionalInfo = VisitAdditionalInfo(welshVisit.reference, "123456")
     val domainEvent = createDomainEventJson(PRISON_VISIT_CHANGED, createAdditionalInformationJson(visitAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
-    val visitDate = visit.startTimestamp.toLocalDate()
+    val visitDate = welshVisit.startTimestamp.toLocalDate()
     val expectedVisitDate = visitDate.format(DateTimeFormatter.ofPattern(EXPECTED_DATE_PATTERN))
     val expectedDayOfWeek = visitDate.dayOfWeek.toString().lowercase().replaceFirstChar { it.titlecase() }
     val templateId = notificationTemplateResolver.getSmsTemplate(SmsTemplateNames.VISIT_UPDATE, LanguagePreference.CY)
@@ -368,17 +369,17 @@ class PrisonVisitUpdateEventSmsTest : EventsIntegrationTestBase() {
 
     // When
     domainEventListenerService.onDomainEvent(jsonSqsMessage)
-    visitSchedulerMockServer.stubGetVisit(bookingReference, visit)
+    visitSchedulerMockServer.stubGetVisit(bookingReference, welshVisit)
     prisonRegisterMockServer.stubGetPrison(prison.prisonId, prison)
 
     // Then
     await untilAsserted { verify(prisonVisitChangedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitNotificationService, times(1)).sendMessage(VisitEventType.UPDATED, visitAdditionalInfo) }
-    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(visit, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
+    await untilAsserted { verify(smsSenderService, times(1)).sendVisitsSms(welshVisit, VisitEventType.UPDATED, visitAdditionalInfo.eventAuditId) }
     await untilAsserted {
       verify(notificationClient, times(1)).sendSms(
         templateId,
-        visit.visitContact.telephone,
+        welshVisit.visitContact.telephone,
         templateVars,
         visitAdditionalInfo.eventAuditId,
       )


### PR DESCRIPTION
## What does this PR do?
Across the API, add support for all templates to eventually accept multiple languages.

In the base handler, remove the common template vars, and force each handler to implement all template vars they need. This should make it clearer what vars are used in each template.

In each handlers template var method, add a conditional when block, to loop all other supported languages, and add the template vars for that chosen language.

In the base handler protected methods which populate some english template vars, add a conditional when block to also loop other languages and add the template vars for that chosen language.

Some minor changes to tests, to fix fallback template assertions.

No extra language templates exist yet, this is all pre-requisite work.

## Important Note
This doesn't include any changes to the Visitor Request / Booker flows. They require a minor rework for the "approved" flow before they can support multiple languages.