### PR TITLE
VB-6594 - Welsh notifications - domain events restructure (visitor requests)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/VisitorRequestNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/VisitorRequestNotificationService.kt
@@ -10,8 +10,8 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.booker.registr
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external.BookerRegistryService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.external.PrisonerContactRegistryService
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorApprovedAdditionalInfo
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRejectedAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorLinkedAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRequestAdditionalInfo
 
 @Service
 class VisitorRequestNotificationService(
@@ -24,9 +24,9 @@ class VisitorRequestNotificationService(
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun sendVisitorRequestApprovedEmail(additionalInfo: VisitorApprovedAdditionalInfo) {
+  fun sendVisitorLinkedEmail(additionalInfo: VisitorLinkedAdditionalInfo) {
     val bookerEventType = BookerEventType.VISITOR_APPROVED
-    LOG.info("Received call to send approval notification for event type $bookerEventType, additional info - $additionalInfo")
+    LOG.info("Received call to send approval notification for event type $bookerEventType, additional info - $additionalInfo (visitor linked)")
     val bookerDetails = bookerRegistryService.getBookerByBookerReference(additionalInfo.bookerReference)
 
     val visitorDetails = VisitorRequestVisitorInfoDto(
@@ -40,7 +40,7 @@ class VisitorRequestNotificationService(
     emailSenderService.sendBookerVisitorEmail(bookerDetails, visitorDetails, bookerEventType, replyToEmailId)
   }
 
-  fun sendVisitorRequestRejectedEmail(additionalInfo: VisitorRejectedAdditionalInfo) {
+  fun sendVisitorRequestRejectedEmail(additionalInfo: VisitorRequestAdditionalInfo) {
     LOG.info("Received call to send rejection notification, additional info - $additionalInfo")
 
     val visitorRequest = bookerRegistryService.getVisitorRequestByReference(additionalInfo.requestReference)
@@ -49,6 +49,18 @@ class VisitorRequestNotificationService(
       "ALREADY_LINKED" -> BookerEventType.VISITOR_REJECTED_ALREADY_LINKED
       else -> throw IllegalStateException("Unexpected rejection reason ${visitorRequest.rejectionReason}")
     }
+    val bookerInfo = BookerInfoDto(reference = visitorRequest.bookerReference, email = visitorRequest.bookerEmail)
+    val visitorDetails = VisitorRequestVisitorInfoDto(visitorRequest)
+
+    val replyToEmailId = replyToEmailResolver.getReplyToEmailIdForPrisoner(visitorRequest.prisonerId)
+    emailSenderService.sendBookerVisitorEmail(bookerInfo, visitorDetails, bookerEventType, replyToEmailId)
+  }
+
+  fun sendVisitorRequestApprovedEmail(additionalInfo: VisitorRequestAdditionalInfo) {
+    val bookerEventType = BookerEventType.VISITOR_APPROVED
+    LOG.info("Received call to send approval notification for event type $bookerEventType, additional info - $additionalInfo (request approved)")
+
+    val visitorRequest = bookerRegistryService.getVisitorRequestByReference(additionalInfo.requestReference)
     val bookerInfo = BookerInfoDto(reference = visitorRequest.bookerReference, email = visitorRequest.bookerEmail)
     val visitorDetails = VisitorRequestVisitorInfoDto(visitorRequest)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/events/additionalinfo/VisitorLinkedAdditionalInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/events/additionalinfo/VisitorLinkedAdditionalInfo.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.e
 
 import jakarta.validation.constraints.NotBlank
 
-data class VisitorApprovedAdditionalInfo(
+data class VisitorLinkedAdditionalInfo(
   @field:NotBlank
   val bookerReference: String,
   @field:NotBlank

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/events/additionalinfo/VisitorRequestAdditionalInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/events/additionalinfo/VisitorRequestAdditionalInfo.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.e
 
 import jakarta.validation.constraints.NotBlank
 
-data class VisitorRejectedAdditionalInfo(
+data class VisitorRequestAdditionalInfo(
   @field:NotBlank
   val requestReference: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorApprovedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorApprovedEventNotifier.kt
@@ -17,7 +17,7 @@ class BookerVisitorApprovedEventNotifier(
 ) : EventNotifier(objectMapper) {
   override fun processEvent(domainEvent: DomainEvent) {
     val visitorLinkedAdditionalInfo: VisitorLinkedAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorLinkedAdditionalInfo::class.java)
-    LOG.info("Enter booking event with info : {}", visitorLinkedAdditionalInfo)
+    LOG.info("Enter BookerVisitorApprovedEventNotifier event with info : {}", visitorLinkedAdditionalInfo)
 
     visitorRequestNotificationService.sendVisitorLinkedEmail(visitorLinkedAdditionalInfo)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorLinkedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorLinkedEventNotifier.kt
@@ -17,7 +17,7 @@ class BookerVisitorLinkedEventNotifier(
 ) : EventNotifier(objectMapper) {
   override fun processEvent(domainEvent: DomainEvent) {
     val visitorLinkedAdditionalInfo: VisitorLinkedAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorLinkedAdditionalInfo::class.java)
-    LOG.info("Enter booking event with info : {}", visitorLinkedAdditionalInfo)
+    LOG.info("Enter BookerVisitorLinkedEventNotifier event with info : {}", visitorLinkedAdditionalInfo)
 
     visitorRequestNotificationService.sendVisitorLinkedEmail(visitorLinkedAdditionalInfo)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorLinkedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorLinkedEventNotifier.kt
@@ -7,10 +7,10 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.VisitorReque
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorLinkedAdditionalInfo
 
-const val BOOKER_VISITOR_APPROVED = "prison-visit-booker.visitor-approved"
+const val BOOKER_VISITOR_LINKED = "prison-visit-booker.visitor-linked"
 
-@Component(value = BOOKER_VISITOR_APPROVED)
-class BookerVisitorApprovedEventNotifier(
+@Component(value = BOOKER_VISITOR_LINKED)
+class BookerVisitorLinkedEventNotifier(
   private val visitorRequestNotificationService: VisitorRequestNotificationService,
   @param:Qualifier("objectMapper")
   private val objectMapper: ObjectMapper,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRejectedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRejectedEventNotifier.kt
@@ -17,7 +17,7 @@ class BookerVisitorRejectedEventNotifier(
 ) : EventNotifier(objectMapper) {
   override fun processEvent(domainEvent: DomainEvent) {
     val visitorRequestAdditionalInfo: VisitorRequestAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorRequestAdditionalInfo::class.java)
-    LOG.info("Enter booking event with info : {}", visitorRequestAdditionalInfo)
+    LOG.info("Enter BookerVisitorRejectedEventNotifier event with info : {}", visitorRequestAdditionalInfo)
 
     visitorRequestNotificationService.sendVisitorRequestRejectedEmail(visitorRequestAdditionalInfo)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRejectedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRejectedEventNotifier.kt
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.VisitorRequestNotificationService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRejectedAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRequestAdditionalInfo
 
 const val BOOKER_VISITOR_REJECTED = "prison-visit-booker.visitor-rejected"
 
@@ -16,9 +16,9 @@ class BookerVisitorRejectedEventNotifier(
   private val objectMapper: ObjectMapper,
 ) : EventNotifier(objectMapper) {
   override fun processEvent(domainEvent: DomainEvent) {
-    val visitorRejectedAdditionalInfo: VisitorRejectedAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorRejectedAdditionalInfo::class.java)
-    LOG.info("Enter booking event with info : $visitorRejectedAdditionalInfo")
+    val visitorRequestAdditionalInfo: VisitorRequestAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorRequestAdditionalInfo::class.java)
+    LOG.info("Enter booking event with info : {}", visitorRequestAdditionalInfo)
 
-    visitorRequestNotificationService.sendVisitorRequestRejectedEmail(visitorRejectedAdditionalInfo)
+    visitorRequestNotificationService.sendVisitorRequestRejectedEmail(visitorRequestAdditionalInfo)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRequestApprovedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRequestApprovedEventNotifier.kt
@@ -5,20 +5,20 @@ import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.VisitorRequestNotificationService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorLinkedAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRequestAdditionalInfo
 
-const val BOOKER_VISITOR_APPROVED = "prison-visit-booker.visitor-approved"
+const val BOOKER_VISITOR_REQUEST_APPROVED = "prison-visit-booker.visitor-request-approved"
 
-@Component(value = BOOKER_VISITOR_APPROVED)
-class BookerVisitorApprovedEventNotifier(
+@Component(value = BOOKER_VISITOR_REQUEST_APPROVED)
+class BookerVisitorRequestApprovedEventNotifier(
   private val visitorRequestNotificationService: VisitorRequestNotificationService,
   @param:Qualifier("objectMapper")
   private val objectMapper: ObjectMapper,
 ) : EventNotifier(objectMapper) {
   override fun processEvent(domainEvent: DomainEvent) {
-    val visitorLinkedAdditionalInfo: VisitorLinkedAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorLinkedAdditionalInfo::class.java)
-    LOG.info("Enter booking event with info : {}", visitorLinkedAdditionalInfo)
+    val visitorRequestAdditionalInfo: VisitorRequestAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorRequestAdditionalInfo::class.java)
+    LOG.info("Enter booking event with info : {}", visitorRequestAdditionalInfo)
 
-    visitorRequestNotificationService.sendVisitorLinkedEmail(visitorLinkedAdditionalInfo)
+    visitorRequestNotificationService.sendVisitorRequestApprovedEmail(visitorRequestAdditionalInfo)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRequestApprovedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRequestApprovedEventNotifier.kt
@@ -17,7 +17,7 @@ class BookerVisitorRequestApprovedEventNotifier(
 ) : EventNotifier(objectMapper) {
   override fun processEvent(domainEvent: DomainEvent) {
     val visitorRequestAdditionalInfo: VisitorRequestAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorRequestAdditionalInfo::class.java)
-    LOG.info("Enter booking event with info : {}", visitorRequestAdditionalInfo)
+    LOG.info("Enter BookerVisitorRequestApprovedEventNotifier event with info : {}", visitorRequestAdditionalInfo)
 
     visitorRequestNotificationService.sendVisitorRequestApprovedEmail(visitorRequestAdditionalInfo)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRequestRejectedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRequestRejectedEventNotifier.kt
@@ -5,20 +5,20 @@ import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.VisitorRequestNotificationService
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.DomainEvent
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorLinkedAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRequestAdditionalInfo
 
-const val BOOKER_VISITOR_APPROVED = "prison-visit-booker.visitor-approved"
+const val BOOKER_VISITOR_REQUEST_REJECTED = "prison-visit-booker.visitor-request-rejected"
 
-@Component(value = BOOKER_VISITOR_APPROVED)
-class BookerVisitorApprovedEventNotifier(
+@Component(value = BOOKER_VISITOR_REQUEST_REJECTED)
+class BookerVisitorRequestRejectedEventNotifier(
   private val visitorRequestNotificationService: VisitorRequestNotificationService,
   @param:Qualifier("objectMapper")
   private val objectMapper: ObjectMapper,
 ) : EventNotifier(objectMapper) {
   override fun processEvent(domainEvent: DomainEvent) {
-    val visitorLinkedAdditionalInfo: VisitorLinkedAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorLinkedAdditionalInfo::class.java)
-    LOG.info("Enter booking event with info : {}", visitorLinkedAdditionalInfo)
+    val visitorRequestAdditionalInfo: VisitorRequestAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorRequestAdditionalInfo::class.java)
+    LOG.info("Enter booking event with info : {}", visitorRequestAdditionalInfo)
 
-    visitorRequestNotificationService.sendVisitorLinkedEmail(visitorLinkedAdditionalInfo)
+    visitorRequestNotificationService.sendVisitorRequestRejectedEmail(visitorRequestAdditionalInfo)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRequestRejectedEventNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/service/listeners/notifiers/BookerVisitorRequestRejectedEventNotifier.kt
@@ -17,7 +17,7 @@ class BookerVisitorRequestRejectedEventNotifier(
 ) : EventNotifier(objectMapper) {
   override fun processEvent(domainEvent: DomainEvent) {
     val visitorRequestAdditionalInfo: VisitorRequestAdditionalInfo = objectMapper.readValue(domainEvent.additionalInformation, VisitorRequestAdditionalInfo::class.java)
-    LOG.info("Enter booking event with info : {}", visitorRequestAdditionalInfo)
+    LOG.info("Enter BookerVisitorRequestRejectedEventNotifier event with info : {}", visitorRequestAdditionalInfo)
 
     visitorRequestNotificationService.sendVisitorRequestRejectedEmail(visitorRequestAdditionalInfo)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/EventsIntegrationTestBase.kt
@@ -46,10 +46,13 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.ev
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.EventFeatureSwitch
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.SQSMessage
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitAdditionalInfo
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorApprovedAdditionalInfo
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRejectedAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorLinkedAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRequestAdditionalInfo
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.BookerVisitorApprovedEventNotifier
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.BookerVisitorLinkedEventNotifier
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.BookerVisitorRejectedEventNotifier
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.BookerVisitorRequestApprovedEventNotifier
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.BookerVisitorRequestRejectedEventNotifier
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.PrisonVisitBookedEventNotifier
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.PrisonVisitCancelledEventNotifier
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.PrisonVisitChangedEventNotifier
@@ -155,7 +158,16 @@ abstract class EventsIntegrationTestBase {
   lateinit var bookerVisitorApprovedEventNotifierSpy: BookerVisitorApprovedEventNotifier
 
   @MockitoSpyBean
+  lateinit var bookerVisitorLinkedEventNotifierSpy: BookerVisitorLinkedEventNotifier
+
+  @MockitoSpyBean
   lateinit var bookerVisitorRejectedEventNotifierSpy: BookerVisitorRejectedEventNotifier
+
+  @MockitoSpyBean
+  lateinit var bookerVisitorRequestApprovedEventNotifierSpy: BookerVisitorRequestApprovedEventNotifier
+
+  @MockitoSpyBean
+  lateinit var bookerVisitorRequestRejectedEventNotifierSpy: BookerVisitorRequestRejectedEventNotifier
 
   @MockitoBean
   lateinit var notificationClient: NotificationClient
@@ -241,7 +253,7 @@ abstract class EventsIntegrationTestBase {
     return builder.toString()
   }
 
-  fun createAdditionalInformationJson(visitorApprovedAdditionalInfo: VisitorApprovedAdditionalInfo): String {
+  fun createAdditionalInformationJson(visitorApprovedAdditionalInfo: VisitorLinkedAdditionalInfo): String {
     val builder = StringBuilder()
     builder.append("{")
     builder.append("\"bookerReference\":\"${visitorApprovedAdditionalInfo.bookerReference}\",")
@@ -251,7 +263,7 @@ abstract class EventsIntegrationTestBase {
     return builder.toString()
   }
 
-  fun createAdditionalInformationJson(visitorRejectedAdditionalInfo: VisitorRejectedAdditionalInfo): String {
+  fun createAdditionalInformationJson(visitorRejectedAdditionalInfo: VisitorRequestAdditionalInfo): String {
     val builder = StringBuilder()
     builder.append("{")
     builder.append("\"requestReference\":\"${visitorRejectedAdditionalInfo.requestReference}\"")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorApprovedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorApprovedEventEmailTest.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateN
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.booker.registry.BookerEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.EventsIntegrationTestBase
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorApprovedAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorLinkedAdditionalInfo
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.BOOKER_VISITOR_APPROVED
 import java.time.LocalDate
 
@@ -35,7 +35,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     )
 
     val bookerInfo = BookerInfoDto(bookerReference, bookerEmailAddress)
-    val bookerAdditionalInfo = VisitorApprovedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
+    val bookerAdditionalInfo = VisitorLinkedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_APPROVED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -65,7 +65,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     val visitorId = 9999L
 
     val bookerInfo = BookerInfoDto(bookerReference, bookerEmailAddress)
-    val bookerAdditionalInfo = VisitorApprovedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
+    val bookerAdditionalInfo = VisitorLinkedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_APPROVED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -85,7 +85,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     val visitorId = 9999L
 
     val bookerInfo = BookerInfoDto(bookerReference, bookerEmailAddress)
-    val bookerAdditionalInfo = VisitorApprovedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
+    val bookerAdditionalInfo = VisitorLinkedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_APPROVED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -103,7 +103,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     // Given
     val visitorId = 1234L
 
-    val bookerAdditionalInfo = VisitorApprovedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
+    val bookerAdditionalInfo = VisitorLinkedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_APPROVED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -121,7 +121,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     // Given
     val visitorId = 1234L
 
-    val bookerAdditionalInfo = VisitorApprovedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
+    val bookerAdditionalInfo = VisitorLinkedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_APPROVED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -144,7 +144,7 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     )
 
     val bookerInfo = BookerInfoDto(bookerReference, bookerEmailAddress)
-    val bookerAdditionalInfo = VisitorApprovedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
+    val bookerAdditionalInfo = VisitorLinkedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_APPROVED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -167,9 +167,9 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     verifyBookerEmailSent(templateId, bookerAdditionalInfo, bookerInfo, VisitorRequestVisitorInfoDto(contact1), templateVars)
   }
 
-  private fun verifyBookerEmailSent(templateId: String, additionalInfo: VisitorApprovedAdditionalInfo, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
+  private fun verifyBookerEmailSent(templateId: String, additionalInfo: VisitorLinkedAdditionalInfo, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
     await untilAsserted { verify(bookerVisitorApprovedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestApprovedEmail(additionalInfo) }
+    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorLinkedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(1)).sendBookerVisitorEmail(bookerInfoDto, visitorInfo, BookerEventType.VISITOR_APPROVED, "00000000-0000-0000-0000-000000000001") }
 
     await untilAsserted {
@@ -183,9 +183,9 @@ class BookerVisitorApprovedEventEmailTest : EventsIntegrationTestBase() {
     }
   }
 
-  private fun verifyBookerEmailNotSent(additionalInfo: VisitorApprovedAdditionalInfo) {
+  private fun verifyBookerEmailNotSent(additionalInfo: VisitorLinkedAdditionalInfo) {
     await untilAsserted { verify(bookerVisitorApprovedEventNotifierSpy, times(1)).processEvent(any()) }
-    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestApprovedEmail(additionalInfo) }
+    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorLinkedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendBookerVisitorEmail(any(), any(), any(), any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorLinkedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorLinkedEventEmailTest.kt
@@ -1,0 +1,77 @@
+package uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.email
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.BookerInfoDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.VisitorRequestVisitorInfoDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.prisoner.contact.registry.ContactWithOptionalPrisonerRelationshipDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateNames
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.booker.registry.BookerEventType
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.EventsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorLinkedAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.BOOKER_VISITOR_LINKED
+import java.time.LocalDate
+
+class BookerVisitorLinkedEventEmailTest : EventsIntegrationTestBase() {
+
+  @Test
+  fun `when visitor linked event is received a visitor approved email is sent to the booker`() {
+    // Given
+    val prisonerId = "A1234BC"
+    val bookerReference = "booker-ref"
+    val bookerEmailAddress = "test@example.com"
+    val visitorId = 1234L
+    val contact = ContactWithOptionalPrisonerRelationshipDto(visitorId, "Visitor", "One", (LocalDate.now().minusYears(30)))
+    val templateId = notificationTemplateResolver.getEmailTemplate(EmailTemplateNames.BOOKER_VISITOR_APPROVED, LanguagePreference.EN)
+    val templateVars = mapOf(
+      "visitor" to "${contact.firstName} ${contact.lastName}",
+    )
+
+    val bookerInfo = BookerInfoDto(bookerReference, bookerEmailAddress)
+    val bookerAdditionalInfo = VisitorLinkedAdditionalInfo(bookerReference, prisonerId, visitorId.toString())
+    val domainEvent = createDomainEventJson(BOOKER_VISITOR_LINKED, createAdditionalInformationJson(bookerAdditionalInfo))
+    val jsonSqsMessage = createSQSMessage(domainEvent)
+
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        bookerInfo.email,
+        templateVars,
+        null,
+        "00000000-0000-0000-0000-000000000001",
+      ),
+    ).thenReturn(buildSendEmailResponse(reference = "test"))
+
+    // When
+    domainEventListenerService.onDomainEvent(jsonSqsMessage)
+    bookerRegistryMockServer.stubGetBooker(bookerReference, bookerInfo)
+    prisonerContactRegisterMockServer.stubSearchContacts(prisonerId, listOf(visitorId), false, listOf(contact))
+
+    // Then
+    await untilAsserted { verify(bookerVisitorLinkedEventNotifierSpy, times(1)).processEvent(any()) }
+    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorLinkedEmail(bookerAdditionalInfo) }
+    await untilAsserted {
+      verify(emailSenderService, times(1)).sendBookerVisitorEmail(
+        bookerInfo,
+        VisitorRequestVisitorInfoDto(contact),
+        BookerEventType.VISITOR_APPROVED,
+        "00000000-0000-0000-0000-000000000001",
+      )
+    }
+    await untilAsserted {
+      verify(notificationClient, times(1)).sendEmail(
+        templateId,
+        bookerInfo.email,
+        templateVars,
+        null,
+        "00000000-0000-0000-0000-000000000001",
+      )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRejectedAlreadyLinkedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRejectedAlreadyLinkedEventEmailTest.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateN
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.booker.registry.BookerEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.EventsIntegrationTestBase
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRejectedAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRequestAdditionalInfo
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.BOOKER_VISITOR_REJECTED
 import java.time.LocalDate
 
@@ -50,7 +50,7 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
     )
 
     val bookerInfo = BookerInfoDto(bookerReference, bookerEmailAddress)
-    val bookerAdditionalInfo = VisitorRejectedAdditionalInfo(visitorRequestReference)
+    val bookerAdditionalInfo = VisitorRequestAdditionalInfo(visitorRequestReference)
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_REJECTED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -76,7 +76,7 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
     // Given
     val visitorRequestReference = "abc-def-ghi"
 
-    val bookerAdditionalInfo = VisitorRejectedAdditionalInfo(visitorRequestReference)
+    val bookerAdditionalInfo = VisitorRequestAdditionalInfo(visitorRequestReference)
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_REJECTED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -93,7 +93,7 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
     // Given
     val visitorRequestReference = "abc-def-ghi"
 
-    val bookerAdditionalInfo = VisitorRejectedAdditionalInfo(visitorRequestReference)
+    val bookerAdditionalInfo = VisitorRequestAdditionalInfo(visitorRequestReference)
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_REJECTED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -134,7 +134,7 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
     )
 
     val bookerInfo = BookerInfoDto(bookerReference, bookerEmailAddress)
-    val bookerAdditionalInfo = VisitorRejectedAdditionalInfo(visitorRequestReference)
+    val bookerAdditionalInfo = VisitorRequestAdditionalInfo(visitorRequestReference)
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_REJECTED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -155,7 +155,7 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
     verifyBookerEmailSent(templateId, bookerAdditionalInfo, bookerInfo, VisitorRequestVisitorInfoDto(visitorRequest), templateVars)
   }
 
-  private fun verifyBookerEmailSent(templateId: String, additionalInfo: VisitorRejectedAdditionalInfo, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
+  private fun verifyBookerEmailSent(templateId: String, additionalInfo: VisitorRequestAdditionalInfo, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
     await untilAsserted { verify(bookerVisitorRejectedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(1)).sendBookerVisitorEmail(bookerInfoDto, visitorInfo, BookerEventType.VISITOR_REJECTED_ALREADY_LINKED, "00000000-0000-0000-0000-000000000001") }
@@ -171,7 +171,7 @@ class BookerVisitorRejectedAlreadyLinkedEventEmailTest : EventsIntegrationTestBa
     }
   }
 
-  private fun verifyBookerEmailNotSent(additionalInfo: VisitorRejectedAdditionalInfo) {
+  private fun verifyBookerEmailNotSent(additionalInfo: VisitorRequestAdditionalInfo) {
     await untilAsserted { verify(bookerVisitorRejectedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendBookerVisitorEmail(any(), any(), any(), any()) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRejectedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRejectedEventEmailTest.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateN
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.booker.registry.BookerEventType
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.EventsIntegrationTestBase
-import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRejectedAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRequestAdditionalInfo
 import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.BOOKER_VISITOR_REJECTED
 import java.time.LocalDate
 
@@ -50,7 +50,7 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
     )
 
     val bookerInfo = BookerInfoDto(bookerReference, bookerEmailAddress)
-    val bookerAdditionalInfo = VisitorRejectedAdditionalInfo(visitorRequestReference)
+    val bookerAdditionalInfo = VisitorRequestAdditionalInfo(visitorRequestReference)
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_REJECTED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -77,7 +77,7 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
     // Given
     val visitorRequestReference = "abc-def-ghi"
 
-    val bookerAdditionalInfo = VisitorRejectedAdditionalInfo(visitorRequestReference)
+    val bookerAdditionalInfo = VisitorRequestAdditionalInfo(visitorRequestReference)
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_REJECTED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -94,7 +94,7 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
     // Given
     val visitorRequestReference = "abc-def-ghi"
 
-    val bookerAdditionalInfo = VisitorRejectedAdditionalInfo(visitorRequestReference)
+    val bookerAdditionalInfo = VisitorRequestAdditionalInfo(visitorRequestReference)
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_REJECTED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -135,7 +135,7 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
     )
 
     val bookerInfo = BookerInfoDto(bookerReference, bookerEmailAddress)
-    val bookerAdditionalInfo = VisitorRejectedAdditionalInfo(visitorRequestReference)
+    val bookerAdditionalInfo = VisitorRequestAdditionalInfo(visitorRequestReference)
     val domainEvent = createDomainEventJson(BOOKER_VISITOR_REJECTED, createAdditionalInformationJson(bookerAdditionalInfo))
     val jsonSqsMessage = createSQSMessage(domainEvent)
 
@@ -157,7 +157,7 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
     verifyBookerEmailSent(templateId, bookerAdditionalInfo, bookerInfo, VisitorRequestVisitorInfoDto(visitorRequest), templateVars)
   }
 
-  private fun verifyBookerEmailSent(templateId: String, additionalInfo: VisitorRejectedAdditionalInfo, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
+  private fun verifyBookerEmailSent(templateId: String, additionalInfo: VisitorRequestAdditionalInfo, bookerInfoDto: BookerInfoDto, visitorInfo: VisitorRequestVisitorInfoDto, templateVars: Map<String, Any>) {
     await untilAsserted { verify(bookerVisitorRejectedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(1)).sendBookerVisitorEmail(bookerInfoDto, visitorInfo, BookerEventType.VISITOR_REJECTED, "00000000-0000-0000-0000-000000000001") }
@@ -173,7 +173,7 @@ class BookerVisitorRejectedEventEmailTest : EventsIntegrationTestBase() {
     }
   }
 
-  private fun verifyBookerEmailNotSent(additionalInfo: VisitorRejectedAdditionalInfo) {
+  private fun verifyBookerEmailNotSent(additionalInfo: VisitorRequestAdditionalInfo) {
     await untilAsserted { verify(bookerVisitorRejectedEventNotifierSpy, times(1)).processEvent(any()) }
     await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestRejectedEmail(additionalInfo) }
     await untilAsserted { verify(emailSenderService, times(0)).sendBookerVisitorEmail(any(), any(), any(), any()) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRequestApprovedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRequestApprovedEventEmailTest.kt
@@ -1,0 +1,137 @@
+package uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.email
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.BookerInfoDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.VisitorRequestDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.VisitorRequestVisitorInfoDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateNames
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.booker.registry.BookerEventType
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.EventsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRequestAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.BOOKER_VISITOR_REQUEST_APPROVED
+import java.time.LocalDate
+
+class BookerVisitorRequestApprovedEventEmailTest : EventsIntegrationTestBase() {
+
+  @Test
+  fun `when visitor request approved event is received a visitor approved email is sent to the booker`() {
+    // Given
+    val prisonerId = "A1234BC"
+    val bookerReference = "booker-ref"
+    val bookerEmailAddress = "test@example.com"
+    val visitorRequestReference = "abc-def-ghi"
+    val visitorRequest = createVisitorRequest(
+      visitorRequestReference = visitorRequestReference,
+      bookerReference = bookerReference,
+      bookerEmailAddress = bookerEmailAddress,
+      prisonerId = prisonerId,
+    )
+    val templateId = notificationTemplateResolver.getEmailTemplate(EmailTemplateNames.BOOKER_VISITOR_APPROVED, LanguagePreference.EN)
+    val templateVars = mapOf(
+      "visitor" to "${visitorRequest.firstName} ${visitorRequest.lastName}",
+    )
+    val bookerInfo = BookerInfoDto(bookerReference, bookerEmailAddress)
+    val bookerAdditionalInfo = VisitorRequestAdditionalInfo(visitorRequestReference)
+    val domainEvent = createDomainEventJson(BOOKER_VISITOR_REQUEST_APPROVED, createAdditionalInformationJson(bookerAdditionalInfo))
+    val jsonSqsMessage = createSQSMessage(domainEvent)
+
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        bookerInfo.email,
+        templateVars,
+        null,
+        "00000000-0000-0000-0000-000000000001",
+      ),
+    ).thenReturn(buildSendEmailResponse(reference = "test"))
+
+    // When
+    bookerRegistryMockServer.stubGetVisitorRequestByReference(visitorRequestReference, visitorRequest)
+    domainEventListenerService.onDomainEvent(jsonSqsMessage)
+
+    // Then
+    await untilAsserted { verify(bookerVisitorRequestApprovedEventNotifierSpy, times(1)).processEvent(any()) }
+    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestApprovedEmail(bookerAdditionalInfo) }
+    await untilAsserted {
+      verify(emailSenderService, times(1)).sendBookerVisitorEmail(
+        bookerInfo,
+        VisitorRequestVisitorInfoDto(visitorRequest),
+        BookerEventType.VISITOR_APPROVED,
+        "00000000-0000-0000-0000-000000000001",
+      )
+    }
+    await untilAsserted {
+      verify(notificationClient, times(1)).sendEmail(
+        templateId,
+        bookerInfo.email,
+        templateVars,
+        null,
+        "00000000-0000-0000-0000-000000000001",
+      )
+    }
+  }
+
+  @Test
+  fun `when visitor request approved event is received but booker registry returns a NOT_FOUND error an email is not sent to the booker`() {
+    // Given
+    val visitorRequestReference = "abc-def-ghi"
+    val bookerAdditionalInfo = VisitorRequestAdditionalInfo(visitorRequestReference)
+    val domainEvent = createDomainEventJson(BOOKER_VISITOR_REQUEST_APPROVED, createAdditionalInformationJson(bookerAdditionalInfo))
+    val jsonSqsMessage = createSQSMessage(domainEvent)
+
+    // When
+    bookerRegistryMockServer.stubGetVisitorRequestByReference(visitorRequestReference, null, HttpStatus.NOT_FOUND)
+    domainEventListenerService.onDomainEvent(jsonSqsMessage)
+
+    // Then
+    verifyVisitorRequestApprovedEmailNotSent(bookerAdditionalInfo)
+  }
+
+  @Test
+  fun `when visitor request approved event is received but booker registry returns an INTERNAL_SERVER error an email is not sent to the booker`() {
+    // Given
+    val visitorRequestReference = "abc-def-ghi"
+    val bookerAdditionalInfo = VisitorRequestAdditionalInfo(visitorRequestReference)
+    val domainEvent = createDomainEventJson(BOOKER_VISITOR_REQUEST_APPROVED, createAdditionalInformationJson(bookerAdditionalInfo))
+    val jsonSqsMessage = createSQSMessage(domainEvent)
+
+    // When
+    bookerRegistryMockServer.stubGetVisitorRequestByReference(visitorRequestReference, null, HttpStatus.INTERNAL_SERVER_ERROR)
+    domainEventListenerService.onDomainEvent(jsonSqsMessage)
+
+    // Then
+    verifyVisitorRequestApprovedEmailNotSent(bookerAdditionalInfo)
+  }
+
+  private fun verifyVisitorRequestApprovedEmailNotSent(additionalInfo: VisitorRequestAdditionalInfo) {
+    await untilAsserted { verify(bookerVisitorRequestApprovedEventNotifierSpy, times(1)).processEvent(any()) }
+    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestApprovedEmail(additionalInfo) }
+    await untilAsserted { verify(emailSenderService, times(0)).sendBookerVisitorEmail(any(), any(), any(), any()) }
+  }
+
+  private fun createVisitorRequest(
+    visitorRequestReference: String,
+    bookerReference: String,
+    bookerEmailAddress: String,
+    prisonerId: String,
+  ): VisitorRequestDto = VisitorRequestDto(
+    reference = visitorRequestReference,
+    bookerReference = bookerReference,
+    bookerEmail = bookerEmailAddress,
+    prisonerId = prisonerId,
+    firstName = "John",
+    lastName = "Smith",
+    dateOfBirth = LocalDate.now().minusYears(21),
+    requestedOn = LocalDate.now(),
+    visitorId = null,
+    rejectionReason = null,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRequestRejectedEventEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/notificationsalertsvsip/integration/domainevents/email/BookerVisitorRequestRejectedEventEmailTest.kt
@@ -1,0 +1,100 @@
+package uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.email
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.BookerInfoDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.VisitorRequestDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.dto.booker.registry.VisitorRequestVisitorInfoDto
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.EmailTemplateNames
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.LanguagePreference
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.enums.booker.registry.BookerEventType
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.integration.domainevents.EventsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.events.additionalinfo.VisitorRequestAdditionalInfo
+import uk.gov.justice.digital.hmpps.notificationsalertsvsip.service.listeners.notifiers.BOOKER_VISITOR_REQUEST_REJECTED
+import java.time.LocalDate
+
+class BookerVisitorRequestRejectedEventEmailTest : EventsIntegrationTestBase() {
+
+  @Test
+  fun `when visitor request rejected event is received a visitor rejected email is sent to the booker`() {
+    // Given
+    val prisonerId = "A1234BC"
+    val bookerReference = "booker-ref"
+    val bookerEmailAddress = "test@example.com"
+    val visitorRequestReference = "abc-def-ghi"
+    val visitorRequest = createVisitorRequest(
+      visitorRequestReference = visitorRequestReference,
+      bookerReference = bookerReference,
+      bookerEmailAddress = bookerEmailAddress,
+      prisonerId = prisonerId,
+      rejectionReason = "REJECT",
+    )
+    val templateId = notificationTemplateResolver.getEmailTemplate(EmailTemplateNames.BOOKER_VISITOR_REJECTED, LanguagePreference.EN)
+    val templateVars = mapOf(
+      "visitor" to "${visitorRequest.firstName} ${visitorRequest.lastName}",
+    )
+    val bookerInfo = BookerInfoDto(bookerReference, bookerEmailAddress)
+    val bookerAdditionalInfo = VisitorRequestAdditionalInfo(visitorRequestReference)
+    val domainEvent = createDomainEventJson(BOOKER_VISITOR_REQUEST_REJECTED, createAdditionalInformationJson(bookerAdditionalInfo))
+    val jsonSqsMessage = createSQSMessage(domainEvent)
+
+    Mockito.`when`(
+      notificationClient.sendEmail(
+        templateId,
+        bookerInfo.email,
+        templateVars,
+        null,
+        "00000000-0000-0000-0000-000000000001",
+      ),
+    ).thenReturn(buildSendEmailResponse(reference = "test"))
+
+    // When
+    bookerRegistryMockServer.stubGetVisitorRequestByReference(visitorRequestReference, visitorRequest)
+    domainEventListenerService.onDomainEvent(jsonSqsMessage)
+
+    // Then
+    await untilAsserted { verify(bookerVisitorRequestRejectedEventNotifierSpy, times(1)).processEvent(any()) }
+    await untilAsserted { verify(visitorRequestNotificationService, times(1)).sendVisitorRequestRejectedEmail(bookerAdditionalInfo) }
+    await untilAsserted {
+      verify(emailSenderService, times(1)).sendBookerVisitorEmail(
+        bookerInfo,
+        VisitorRequestVisitorInfoDto(visitorRequest),
+        BookerEventType.VISITOR_REJECTED,
+        "00000000-0000-0000-0000-000000000001",
+      )
+    }
+    await untilAsserted {
+      verify(notificationClient, times(1)).sendEmail(
+        templateId,
+        bookerInfo.email,
+        templateVars,
+        null,
+        "00000000-0000-0000-0000-000000000001",
+      )
+    }
+  }
+
+  private fun createVisitorRequest(
+    visitorRequestReference: String,
+    bookerReference: String,
+    bookerEmailAddress: String,
+    prisonerId: String,
+    rejectionReason: String,
+  ): VisitorRequestDto = VisitorRequestDto(
+    reference = visitorRequestReference,
+    bookerReference = bookerReference,
+    bookerEmail = bookerEmailAddress,
+    prisonerId = prisonerId,
+    firstName = "John",
+    lastName = "Smith",
+    dateOfBirth = LocalDate.now().minusYears(21),
+    requestedOn = LocalDate.now(),
+    visitorId = null,
+    rejectionReason = rejectionReason,
+  )
+}


### PR DESCRIPTION
## What does this PR do?

Previously, the visitor approved event was being shared by 2 flows; a manual linking flow and a visitor request approved flow.

Because we are aiming to introduce welsh templates, we need to split this combined flow into 2 separate ones.

Add 3 new event notifiers which will be used to consume the following events:

visitor linked - this originally combined with the request approved, but is now split into it's own event. It will trigger when staff manually link a visitor without a visitor request.

visitor request approved - as above, originally combined with the visitor linked, but is now split into it's own event. it will trigger when a visitor request is approved.

visitor request rejected - no actual functinoality changes here; it's just an event rename. So i've created a new event notifier to capture it without breaking the existing one.

Updated all integration tests too.